### PR TITLE
Fix checking boxes in F1 bug report screen

### DIFF
--- a/scenes/menus/feedback/tickbox.gd
+++ b/scenes/menus/feedback/tickbox.gd
@@ -3,7 +3,7 @@ extends Control
 onready var sprite = $Sprite
 var pressed = false
 
-func _on_Tickbox_pressed():
+func _on_Button_pressed():
 	pressed = !pressed
 	if pressed:
 		Singleton.get_node("SFX/Confirm").play()


### PR DESCRIPTION
Previously pressing F1 on the main menu and trying to check boxes would result in nothing happening, and an error in the Godot debugger:

```
E 0:00:05.915   emit_signal: Error calling method from signal 'pressed': 'Control(tickbox.gd)::_on_Button_pressed': Method not found..
  <C++ Source>  core/object.cpp:1242 @ emit_signal()
```

Renaming `res://scenes/menus/feedback/tickbox.gd#_on_Tickbox_pressed` to `_on_Button_pressed` fixes the error message and makes checking the box behave as expected.

(Is this the correct fix? I don't know enough Godot to be sure.)