### PR TITLE
Fix bug where Mario gets stuck on ground hovering if you hold Hover

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -536,8 +536,8 @@ func action_spin() -> void:
 		spin_frames = SPIN_TIME
 
 
-var __fludd_spraying: bool = false
-var __fludd_spraying_rising: bool = false
+var _fludd_spraying: bool = false
+var _fludd_spraying_rising: bool = false
 # If _physics_process() never calls player_physics() but checks fludd_spraying(),
 # keep initial value as valid to avoid runtime crashes.
 var fludd_stale: bool = false
@@ -548,18 +548,19 @@ func fludd_spraying(allow_stale: bool = false) -> bool:
 	# ensure we have already processed hovering this frame.
 	if !allow_stale:
 		assert(!fludd_stale)
-	return __fludd_spraying
+	return _fludd_spraying
+
 
 func fludd_spraying_rising(allow_stale: bool = false) -> bool:
 	if !allow_stale:
 		assert(!fludd_stale)
-	return __fludd_spraying_rising
+	return _fludd_spraying_rising
 
 var rocket_charge: int = 0
 func fludd_control():
 	fludd_stale = false
-	__fludd_spraying = false
-	__fludd_spraying_rising = false
+	_fludd_spraying = false
+	_fludd_spraying_rising = false
 	
 	if grounded:
 		Singleton.power = 100 # TODO: multi fludd
@@ -576,13 +577,13 @@ func fludd_control():
 				| S.DIVE
 			)
 	):
-		__fludd_spraying = true
+		_fludd_spraying = true
 		match Singleton.nozzle:
 			Singleton.n.hover:
 				fludd_strain = true
 				double_anim_cancel = true
 				if state != S.DIVE:
-					__fludd_spraying_rising = true
+					_fludd_spraying_rising = true
 				if state != S.TRIPLE_JUMP or (abs(sprite.rotation_degrees) < 90 or abs(sprite.rotation_degrees) > 270):
 					if state & (S.DIVE | S.TRIPLE_JUMP):
 						vel.y *= 1 - 0.02 * FPS_MOD
@@ -622,7 +623,7 @@ func fludd_control():
 				else:
 					fludd_strain = false
 				if rocket_charge >= 14 / FPS_MOD and (state != S.TRIPLE_JUMP or ((abs(sprite.rotation_degrees) < 20 or abs(sprite.rotation_degrees) > 340))):
-					__fludd_spraying_rising = true
+					_fludd_spraying_rising = true
 					if state == S.DIVE:
 						# set sign of velocity (could use ternary but they're icky)
 						var multiplier = 1


### PR DESCRIPTION
Previously if you held the Hover key through any period that Mario could not begin hovering off the ground (eg. grounded spin, landing from a hover, dive), Mario would remain stuck on the ground and play the hover sound on every frame, but be unable to take off except on the first frame you press the Hover key, or when you walk off a ledge into the air.

- This fixes the FLUDD/movement code so you can lift off the ground whenever you are hovering and accelerating upwards.
	- Is the correct fix to give FLUDD over 4 units of vertical speed? I doubt it (but am not 100% sure), since in the original game you can spin then take off without jumping, both on land and in water (where FLUDD gives practically no vertical speed initially).
		- Oddly in the original game, if you spun then held FLUDD, you'd hear the FLUDD sound once the damaging spin ends even as you're still holding Spin, even though FLUDD does not spray and you don't lose water until you release Spin.
- This changes the FLUDD/movement code so you can only lift off the ground when the rocket nozzle fires, not when you first press FLUDD (although FLUDD was able to lift off anyway in the past, because it had more than 4 units per second of upwards speed and FLUDD didn't, see `get_snap()` returned vector).
- This changes the ground failsafe code so holding FLUDD without water or in rocket mode does not prevent you from "landing" in between slopes, only hovering or launching the rocket does. (It's still a bit awkward and interrupting movement, to have to wait 10 frames after landing in a crack between rocks before you can jump. Interestingly, in the original game's intro, this diagonal rock was walkable.)

Unresolved questions:

- [ ] This changes the FLUDD/movement code so you stick to the ground while hovering and accelerating mid-dive-slide (which matches regular dive-sliding, and I was told was expected on Discord). Unfortunately when Mario slides down ground that abruptly slopes down, Mario abruptly turns to face down and the water stream abruptly points upwards, which sometimes looks quite odd. Should this be reconsidered?
	- In the original SM63, at least in Bob-omb Battlefield, Mario sticks to the cannon when sliding up the (walkable) side onto the level surface, but lifts off into the air when sliding along the top and falling off the (walkable) side. However, SM63 has an intro stage with similarly sloped rocks, which are walkable in 63 and non-walkable in Redux, so I'm not sure how relevant this comparison is? \
	![firefox_KTpLt0mj5K](https://user-images.githubusercontent.com/913957/196414651-b6cab27b-9915-48d2-9ceb-53e5b45058f5.png)
	- I don't know if it's possible in Godot, to make Mario stick to ground sloping down under you if it's flat but not downhill.
	- In the original SM63, dive-sliding Mario both slopes *less* than the slope of the ground (a limit of 45 degrees? less sloped when moving quickly? not sure, but somehow Mario is *less* sloped on this 60-degree cannon than the ~45-degree ground to the left of this cannon), and gradually turns between flat and facing uphill (didn't look in decomp). Mario does not appear to turn gradually in Redux, as far as I can tell visually (didn't look in source).
- [ ] Messy commit log, IDK if you like the `fludd_stale` and `allow_stale` checks in the code (to prevent accidentally using 1-frame-old FLUDD state without realizing).

Not fixed:

- initiating a fludd spray during the flip of a triple jump plays the spray sound on every frame, until the flip ends