### PR TITLE
Fix and improve on warp pipes

### DIFF
--- a/classes/interactable/pipe/exit_pipe.gd
+++ b/classes/interactable/pipe/exit_pipe.gd
@@ -1,0 +1,8 @@
+extends Pipe
+
+onready var sweep_effect = $"/root/Singleton/WindowWarp"
+
+export var scene_path : String
+
+func _warp(pos):
+	sweep_effect.warp(pos, scene_path)

--- a/classes/interactable/pipe/exit_pipe.gd
+++ b/classes/interactable/pipe/exit_pipe.gd
@@ -1,8 +1,0 @@
-extends Pipe
-
-onready var sweep_effect = $"/root/Singleton/WindowWarp"
-
-export var scene_path : String
-
-func _warp(pos):
-	sweep_effect.warp(pos, scene_path)

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -89,9 +89,9 @@ func _on_mario_top(body):
 
 
 func _on_mario_off(_body):
-		if !slid: # w/o this check, target will get nulled during the slide
-			can_warp = false # Or else he won't
-			target = null
+	if !slid: # w/o this check, target will get nulled during the slide
+		can_warp = false # Or else he won't
+		target = null
 
 
 func set_disabled(val):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -1,6 +1,7 @@
 extends StaticBody2D
 
 const PIPE_HEIGHT = 30
+const SLIDE_SPEED = 0.7
 const SLIDE_LENGTH = 60
 const CENTERING_SPEED_SLOW = 0.25
 const CENTERING_SPEED_FAST = 0.75
@@ -26,13 +27,14 @@ func _physics_process(_delta):
 		else:
 			target.position.x = lerp(target.position.x, position.x, CENTERING_SPEED_SLOW)
 			if target.position.y < position.y:
-				target.position.y += 0.7
+				target.position.y += SLIDE_SPEED
 	
 	if can_warp:
 		# Begin entering pipe if down is pressed 
 		if Input.is_action_pressed("down") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			target.get_node("Voice").volume_db = -INF # Dumb solution to mario making dive sounds
 			target.get_node("Character").set_animation("front")
+			target.dive_correct(0)
 			
 			sound.play()
 			target.locked = true # Affects mario's whole input process

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -63,11 +63,13 @@ func _physics_process(_delta):
 	# Tick the slide timer
 	if slid:
 		slide_timer += 1
+	
+	# When the timer rings, warp Mario
+	if slide_timer == SLIDE_LENGTH:
+		target.position = target_pos
 		
-	if slide_timer == SLIDE_LENGTH: # Mario then will be teleported as the "true" variables return to false
 		# Reset Mario to normal
 		target.get_node("Voice").volume_db = -5
-		target.position = target_pos
 		target.locked = false
 		target.switch_state(target.S.NEUTRAL)
 		target.switch_anim("walk")
@@ -87,8 +89,9 @@ func _on_mario_top(body):
 
 
 func _on_mario_off(_body):
-		can_warp = false # Or else he won't
-		target = null
+		if !slid: # w/o this check, target will get nulled during the slide
+			can_warp = false # Or else he won't
+			target = null
 
 
 func set_disabled(val):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -1,4 +1,3 @@
-class_name Pipe
 extends StaticBody2D
 
 const PIPE_HEIGHT = 30
@@ -7,8 +6,13 @@ const SLIDE_LENGTH = 60
 const CENTERING_SPEED_SLOW = 0.25
 const CENTERING_SPEED_FAST = 0.75
 
+const TRANSITION_SPEED_IN = 15
+const TRANSITION_SPEED_OUT = 15
+
 export var disabled = false setget set_disabled
 export var target_pos = Vector2.ZERO
+export var move_to_scene = false
+export var scene_path : String
 
 var can_warp = false # this variable is changed when mario enters the pipe's small area2D
 var slid = false # this is true while Mario is sliding into the pipe
@@ -16,6 +20,7 @@ var slide_timer = 0 # This counts up while Mario slides until he reaches the end
 var store_state = 0
 var target = null
 
+onready var sweep_effect = $"/root/Singleton/WindowWarp"
 onready var sound = $SFX # for sound effect
 onready var ride_area = $Area2D
 
@@ -67,24 +72,23 @@ func _physics_process(_delta):
 	
 	# When the timer rings, warp Mario
 	if slide_timer == SLIDE_LENGTH:
-		_warp(target_pos)
-
-
-func _warp(pos):
-	# Teleport Mario someplace within the level
-	target.position = pos
-		
-	# Reset Mario to normal
-	target.get_node("Voice").volume_db = -5
-	target.locked = false
-	target.switch_state(target.S.NEUTRAL)
-	target.switch_anim("walk")
-	target.dive_correct(0)
-	
-	# Reset this pipe to ready
-	sound.stop()
-	slide_timer = 0
-	slid = false
+		if move_to_scene:
+			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+		else:
+			# Teleport Mario someplace within the level
+			target.position = target_pos
+				
+			# Reset Mario to normal
+			target.get_node("Voice").volume_db = -5
+			target.locked = false
+			target.switch_state(target.S.NEUTRAL)
+			target.switch_anim("walk")
+			target.dive_correct(0)
+			
+			# Reset this pipe to ready
+			sound.stop()
+			slide_timer = 0
+			slid = false
 
 
 func _on_mario_top(body):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -40,7 +40,7 @@ func _physics_process(_delta):
 		if Input.is_action_pressed("down") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			target.get_node("Voice").volume_db = -INF # Dumb solution to mario making dive sounds
 			target.get_node("Character").set_animation("front")
-			target.dive_correct(0)
+			target.get_node("Character").rotation = 0
 			
 			sound.play()
 			target.locked = true # Affects mario's whole input process

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -66,19 +66,24 @@ func _physics_process(_delta):
 	
 	# When the timer rings, warp Mario
 	if slide_timer == SLIDE_LENGTH:
-		target.position = target_pos
+		_warp(target_pos)
+
+
+func _warp(pos):
+	# Teleport Mario someplace within the level
+	target.position = pos
 		
-		# Reset Mario to normal
-		target.get_node("Voice").volume_db = -5
-		target.locked = false
-		target.switch_state(target.S.NEUTRAL)
-		target.switch_anim("walk")
-		target.dive_correct(0)
-		
-		# Reset this pipe to ready
-		sound.stop()
-		slide_timer = 0
-		slid = false
+	# Reset Mario to normal
+	target.get_node("Voice").volume_db = -5
+	target.locked = false
+	target.switch_state(target.S.NEUTRAL)
+	target.switch_anim("walk")
+	target.dive_correct(0)
+	
+	# Reset this pipe to ready
+	sound.stop()
+	slide_timer = 0
+	slid = false
 
 
 func _on_mario_top(body):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -11,8 +11,6 @@ const TRANSITION_SPEED_OUT = 15
 
 export var disabled = false setget set_disabled
 export var target_pos = Vector2.ZERO
-export var move_to_scene = false
-export var scene_path : String
 
 var can_warp = false # this variable is changed when mario enters the pipe's small area2D
 var slid = false # this is true while Mario is sliding into the pipe
@@ -20,7 +18,6 @@ var slide_timer = 0 # This counts up while Mario slides until he reaches the end
 var store_state = 0
 var target = null
 
-onready var sweep_effect = $"/root/Singleton/WindowWarp"
 onready var sound = $SFX # for sound effect
 onready var ride_area = $Area2D
 
@@ -69,13 +66,9 @@ func _physics_process(_delta):
 	# Tick the slide timer
 	if slid:
 		slide_timer += 1
-		
-	# Begin scene-change transition early if needed (looks better that way)
-	if slide_timer == SLIDE_LENGTH - TRANSITION_SPEED_IN and move_to_scene:
-			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
 	
 	# If not changing scenes, warp Mario on timer ring
-	if slide_timer == SLIDE_LENGTH and move_to_scene != true:
+	if slide_timer == SLIDE_LENGTH:
 		# Teleport Mario someplace within the level
 		target.position = target_pos
 			

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -11,6 +11,8 @@ const TRANSITION_SPEED_OUT = 15
 
 export var disabled = false setget set_disabled
 export var target_pos = Vector2.ZERO
+export var move_to_scene = false
+export var scene_path : String
 
 var can_warp = false # this variable is changed when mario enters the pipe's small area2D
 var slid = false # this is true while Mario is sliding into the pipe
@@ -18,6 +20,7 @@ var slide_timer = 0 # This counts up while Mario slides until he reaches the end
 var store_state = 0
 var target = null
 
+onready var sweep_effect = $"/root/Singleton/WindowWarp"
 onready var sound = $SFX # for sound effect
 onready var ride_area = $Area2D
 
@@ -66,9 +69,13 @@ func _physics_process(_delta):
 	# Tick the slide timer
 	if slid:
 		slide_timer += 1
+		
+	# Begin scene-change transition early if needed (looks better that way)
+	if slide_timer == SLIDE_LENGTH - TRANSITION_SPEED_IN and move_to_scene:
+			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
 	
 	# If not changing scenes, warp Mario on timer ring
-	if slide_timer == SLIDE_LENGTH:
+	if slide_timer == SLIDE_LENGTH and move_to_scene != true:
 		# Teleport Mario someplace within the level
 		target.position = target_pos
 			

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -1,3 +1,4 @@
+class_name Pipe
 extends StaticBody2D
 
 const PIPE_HEIGHT = 30

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -69,26 +69,27 @@ func _physics_process(_delta):
 	# Tick the slide timer
 	if slid:
 		slide_timer += 1
-	
-	# When the timer rings, warp Mario
-	if slide_timer == SLIDE_LENGTH:
-		if move_to_scene:
+		
+	# Begin scene-change transition early if needed (looks better that way)
+	if slide_timer == SLIDE_LENGTH - TRANSITION_SPEED_IN and move_to_scene:
 			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
-		else:
-			# Teleport Mario someplace within the level
-			target.position = target_pos
-				
-			# Reset Mario to normal
-			target.get_node("Voice").volume_db = -5
-			target.locked = false
-			target.switch_state(target.S.NEUTRAL)
-			target.switch_anim("walk")
-			target.dive_correct(0)
+	
+	# If not changing scenes, warp Mario on timer ring
+	if slide_timer == SLIDE_LENGTH and move_to_scene != true:
+		# Teleport Mario someplace within the level
+		target.position = target_pos
 			
-			# Reset this pipe to ready
-			sound.stop()
-			slide_timer = 0
-			slid = false
+		# Reset Mario to normal
+		target.get_node("Voice").volume_db = -5
+		target.locked = false
+		target.switch_state(target.S.NEUTRAL)
+		target.switch_anim("walk")
+		target.dive_correct(0)
+		
+		# Reset this pipe to ready
+		sound.stop()
+		slide_timer = 0
+		slid = false
 
 
 func _on_mario_top(body):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -25,11 +25,11 @@ func _physics_process(_delta):
 	if slid:
 		# Slide Mario down into the pipe
 		if target.state == 7:
-			target.position.y = position.y
-			target.position.x = lerp(target.position.x, position.x, CENTERING_SPEED_FAST)
+			target.position.y = global_position.y
+			target.position.x = lerp(target.position.x, global_position.x, CENTERING_SPEED_FAST)
 		else:
-			target.position.x = lerp(target.position.x, position.x, CENTERING_SPEED_SLOW)
-			if target.position.y < position.y:
+			target.position.x = lerp(target.position.x, global_position.x, CENTERING_SPEED_SLOW)
+			if target.position.y < global_position.y:
 				target.position.y += SLIDE_SPEED
 	
 	if can_warp:
@@ -42,8 +42,8 @@ func _physics_process(_delta):
 			sound.play()
 			target.locked = true # Affects mario's whole input process
 			target.position = Vector2(
-				lerp(target.position.x, position.x, CENTERING_SPEED_SLOW),
-				position.y - PIPE_HEIGHT)
+				lerp(target.position.x, global_position.x, CENTERING_SPEED_SLOW),
+				global_position.y - PIPE_HEIGHT)
 			
 			# Warping will be disabled, then increment will start as mario slides down
 			can_warp = false
@@ -52,10 +52,10 @@ func _physics_process(_delta):
 		elif (target.state == target.S.POUND and target.pound_state != target.Pound.SPIN):
 			sound.play()
 			target.locked = true # Affects mario's whole input process
-			#target.position = Vector2(position.x, position.y - 30)
+			#target.position = Vector2(global_position.x, global_position.y - 30)
 			target.position = Vector2(
-				lerp(target.position.x, position.x, CENTERING_SPEED_FAST),
-				position.y - PIPE_HEIGHT)
+				lerp(target.position.x, global_position.x, CENTERING_SPEED_FAST),
+				global_position.y - PIPE_HEIGHT)
 			
 			# Warping will be disabled, then timer will start as mario slides down
 			can_warp = false

--- a/classes/interactable/pipe/pipe.tscn
+++ b/classes/interactable/pipe/pipe.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://classes/interactable/pipe/pipe.gd" type="Script" id=3]
 
 [sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 4.36713, 8 )
+extents = Vector2( 4.36713, 15 )
 
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 15.9792, 16.0339 )
@@ -23,14 +23,23 @@ collision_layer = 0
 collision_mask = 2
 input_pickable = false
 monitorable = false
+__meta__ = {
+"_editor_description_": "Detects if Mario is on pipe"
+}
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-position = Vector2( 0, -16 )
+position = Vector2( 0, -9 )
 shape = SubResource( 1 )
+__meta__ = {
+"_editor_description_": ""
+}
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 z_index = 1
 shape = SubResource( 2 )
+__meta__ = {
+"_editor_description_": ""
+}
 
 [node name="SFX" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 1 )


### PR DESCRIPTION
Previously, when Mario entered a warp pipe, the slide-down animation would get interrupted midway by the following error:
```
Invalid get index 'state' (on base: 'Nil').
```
The game would then softlock with Mario still in the pipe.

This bug occurred because Mario, when sliding, would exit the Area2D responsible for checking if he's on top of the pipe. When Mario exits this area, the pipe nulls its reference to him--but this was happening while he was still in the pipe, making it impossible for the pipe to finish sliding him.

To fix this, the code was altered not to null Mario's reference if he's sliding down the pipe when he leaves the Area2D, and the Area2D itself was extended downwards so Mario doesn't leave it during the slide.

- [ ] In process of making this fix, I rearranged the code to follow the code conventions, cleaned it up some, and commented it for newcomers. You want me to fix or revert any of this?
- [ ] How about the variable renaming? Is that liable to break anything? Cause confusion?