### PR TITLE
Use interactables' global position when Mario slides up to them

### DIFF
--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -9,7 +9,7 @@ onready var dialog = $"/root/Main/Player/Camera/GUI/DialogBox"
 
 
 func _interact_with(body):
-	body.sign_x = global_position.x + x_offset * sign(body.position.x - global_position.x)
+	body.sign_x = global_position.x + x_offset * sign(body.global_position.x - global_position.x)
 	body.vel = Vector2.ZERO
 	body.locked = true
 	body.sign_frames = 1

--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -9,7 +9,7 @@ onready var dialog = $"/root/Main/Player/Camera/GUI/DialogBox"
 
 
 func _interact_with(body):
-	body.sign_x = position.x + x_offset * sign(body.position.x - position.x)
+	body.sign_x = global_position.x + x_offset * sign(body.position.x - global_position.x)
 	body.vel = Vector2.ZERO
 	body.locked = true
 	body.sign_frames = 1

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1215,7 +1215,7 @@ var collect_pos_final = Vector2.INF
 var sign_x: float = INF
 func locked_behaviour():
 	if sign_x != INF:
-		position.x = sign_x + (position.x - sign_x) * 0.75
+		global_position.x = sign_x + (global_position.x - sign_x) * 0.75
 	if collect_pos_final != Vector2.INF:
 		switch_anim("spin")
 		position = collect_pos_init + sin(min(collect_frames / 230.0, 1) * PI / 2) * (collect_pos_final - collect_pos_init)


### PR DESCRIPTION
When Mario interacts with a sign (or presumably a Toad), he shifts over to a designated spot relative to the sign (or Toad).

Vexxter on Discord discovered that when signs are children of other nodes, the parent nodes' positions are not taken into account when Mario shifts like this.

This means that if you load in a scene then move its root node, reading a sign in that scene will teleport Mario somewhere crazy (specifically to the global position with the same coordinates as the sign's local position).

Using the interactable's global position takes parent nodes into account, thereby solving the problem.

Just to be on the safe side, also made sure Mario uses global coordinates for this shift animation. He's a child of the scene root, and the scene root is no more guaranteed to be at (0,0) than any other node....