### PR TITLE
Update and improve doors

### DIFF
--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -28,8 +28,8 @@ func _player_offset() -> int:
 	return 0
 
 
-func _player_begin_animation(mario):
-	mario.switch_anim("back")
+func _player_begin_animation(player):
+	player.switch_anim("back")
 
 
 func _door_begin_animation():

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,18 +1,18 @@
-tool
 class_name Door
 extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
 
-export var door_graphic : SpriteFrames setget set_door_graphic
+export var door_graphic : SpriteFrames
 
 var player_fade_start_time : int
 var player_fade_rate : float
 var door_close_start_time : int
 
-func set_door_graphic(graphic : SpriteFrames):
-	door_graphic = graphic
+func _ready():
+	_set_sprite_frames(door_graphic)
 	
+	# Load animation timings
 	if door_graphic is DoorSkin:
 		# Resource has animation timings saved in it; load them.
 		player_fade_start_time = door_graphic.player_fade_start_time
@@ -23,10 +23,6 @@ func set_door_graphic(graphic : SpriteFrames):
 		player_fade_start_time = DoorSkin.DEFAULT_PLAYER_FADE_START
 		player_fade_rate = DoorSkin.DEFAULT_PLAYER_FADE_RATE
 		door_close_start_time = DoorSkin.DEFAULT_DOOR_CLOSE_START
-
-
-func _ready():
-	_set_sprite_frames(door_graphic)
 
 
 func _update_animation(_frame: int, _player):

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -2,6 +2,9 @@ class_name Door
 extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
+const ANIM_PLAYER_BEGIN_FADEOUT = 8
+const ANIM_PLAYER_FADE_RATE = 0.1
+const ANIM_DOOR_BEGIN_CLOSE = 32
 
 export var door_graphic : SpriteFrames
 
@@ -15,9 +18,17 @@ func _update_animation(_frame: int, _player):
 	
 	if _frame == 0:
 		# Start door opening animation
-		_door_begin_animation()
+		_door_open()
 		# Start player's enter animation
 		_player_begin_animation(_player)
+	if _frame >= ANIM_PLAYER_BEGIN_FADEOUT:
+		# Fade player down a little bit
+		_player.sprite.modulate.a -= ANIM_PLAYER_FADE_RATE
+	if _frame == ANIM_DOOR_BEGIN_CLOSE:
+		_door_close()
+	if _frame == _animation_length():
+		# Reset player to fully opaque
+		_player.sprite.modulate.a = 1
 
 
 func _animation_length():
@@ -37,8 +48,11 @@ func _player_begin_animation(player):
 	player.read_pos_x = global_position.x + _player_offset()
 
 
-func _door_begin_animation():
+func _door_open():
 	$Sprite.play("opening")
+
+func _door_close():
+	$Sprite.play("closing")
 
 
 func _set_sprite_frames(sprite_frames: SpriteFrames):

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -60,7 +60,6 @@ func _physics_process(_delta):
 
 
 func _on_mario_touch(body):
-	print_debug("Touched door")
 	if body.state == body.S.NEUTRAL:
 		can_warp = true
 		target = body
@@ -68,6 +67,5 @@ func _on_mario_touch(body):
 
 func _on_mario_off(_body):
 	if !entering: # w/o this check, target will get nulled when animation ends
-		print_debug("left door")
 		can_warp = false # Or else he won't
 		target = null

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -7,6 +7,7 @@ const CENTERING_SPEED = 0.25
 const TRANSITION_SPEED_IN = 15
 const TRANSITION_SPEED_OUT = 15
 
+export var sprite : SpriteFrames
 export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
@@ -18,6 +19,9 @@ var target = null
 var store_state = 0
 
 onready var sweep_effect = $"/root/Singleton/WindowWarp"
+
+func _ready():
+	$DoorSprite.frames = sprite
 
 func _physics_process(_delta):
 	if entering:

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -9,13 +9,13 @@ func _ready():
 	_set_sprite_frames(door_graphic)
 
 
-func _update_animation(_frame: int, _mario):
+func _update_animation(_frame: int, _player):
 	# Gradually center Mario
-	._mario_shift_to_position(_mario, global_position.x + _mario_offset(), CENTERING_SPEED)
+	._player_shift_to_position(_player, global_position.x + _player_offset(), CENTERING_SPEED)
 	
 	if _frame == 0:
 		# Start Mario's enter animation
-		_mario_begin_animation(_mario)
+		_player_begin_animation(_player)
 		# Start door opening animation
 		_door_begin_animation()
 
@@ -24,11 +24,11 @@ func _animation_length():
 	return 60
 
 
-func _mario_offset() -> int:
+func _player_offset() -> int:
 	return 0
 
 
-func _mario_begin_animation(mario):
+func _player_begin_animation(mario):
 	mario.switch_anim("back")
 
 

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,8 +1,6 @@
 class_name Door
 extends InteractableWarp
 
-const CENTERING_SPEED = 0.25
-
 export var door_graphic : SpriteFrames
 
 var player_fade_start_time : int
@@ -25,10 +23,7 @@ func _ready():
 		door_close_start_time = DoorSkin.DEFAULT_DOOR_CLOSE_START
 
 
-func _update_animation(_frame: int, _player):
-	# Gradually center the player
-	#._player_shift_to_position(_player, global_position.x + _player_offset(), CENTERING_SPEED)
-	
+func _update_animation(_frame: int, _player):	
 	if _frame == 0:
 		# Start door opening animation
 		_door_open()

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -6,7 +6,7 @@ const CENTERING_SPEED = 0.25
 export var door_graphic : SpriteFrames
 
 func _ready():
-	$DoorSprite.frames = door_graphic
+	_set_sprite_frames(door_graphic)
 
 
 func _update_animation(_frame: int, _mario):
@@ -33,4 +33,8 @@ func _mario_begin_animation(mario):
 
 
 func _door_begin_animation():
-	$DoorSprite.play("opening")
+	$Sprite.play("opening")
+
+
+func _set_sprite_frames(sprite_frames: SpriteFrames):
+	$Sprite.frames = sprite_frames

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,38 +1,23 @@
 class_name Door
 extends InteractableExit
 
-const ENTER_LENGTH = 60
-const ENTER_BEGIN_TRANSITION = ENTER_LENGTH - TRANSITION_SPEED_IN
 const CENTERING_SPEED = 0.25
 
-export var sprite : SpriteFrames
+export var doorGraphic : SpriteFrames
 
 func _ready():
-	$DoorSprite.frames = sprite
+	$DoorSprite.frames = doorGraphic
 
 
 func _update_animation(_frame: int, _mario):
 	# Gradually center Mario
 	_mario.global_position.x = lerp(_mario.global_position.x, global_position.x, CENTERING_SPEED)
 	
-	match _frame:
-		ENTER_BEGIN_TRANSITION:
-			#Play transition animation
-			return EnterState.CAN_TRANSITION
-		ENTER_LENGTH:
-			return EnterState.DONE
-		0:
-			# Start Mario's enter animation
-			_mario.get_node("Character").set_animation("back")
-			# Start door opening animation
-			$DoorSprite.play("opening")
-			
-			return EnterState.ENTERING
-		_:
-			return EnterState.ENTERING
+	if _frame == 0:
+		# Start Mario's enter animation
+		_mario.get_node("Character").set_animation("back")
+		# Start door opening animation
+		$DoorSprite.play("opening")
 
-
-func _scene_transition(target_pos, scene_path):
-	# Default warp transition is a star iris.
-	var sweep_effect = $"/root/Singleton/WindowWarp"
-	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+func _animation_length():
+	return 60

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -21,7 +21,7 @@ onready var sweep_effect = $"/root/Singleton/WindowWarp"
 
 func _physics_process(_delta):
 	if entering:
-		target.position.x = lerp(target.position.x, position.x, CENTERING_SPEED)
+		target.position.x = lerp(target.position.x, global_position.x, CENTERING_SPEED)
 		# Do entering animation
 		pass
 	

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -43,7 +43,7 @@ func _animation_length():
 	return 60
 
 
-func _player_offset() -> int:
+func _enter_pos_offset() -> int:
 	return 0
 
 
@@ -53,7 +53,7 @@ func _player_begin_animation(player):
 	# NOTE: read_pos_x movement currently has a lerp factor of 0.75 per frame.
 	# Door entry may feel smoother with a factor of 0.25
 	# (more consistent with player movement).
-	player.read_pos_x = global_position.x + _player_offset()
+	player.read_pos_x = global_position.x + _enter_pos_offset()
 
 
 func _door_open():

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,75 +1,38 @@
 class_name Door
-extends Area2D
+extends InteractableExit
 
 const ENTER_LENGTH = 60
+const ENTER_BEGIN_TRANSITION = ENTER_LENGTH - TRANSITION_SPEED_IN
 const CENTERING_SPEED = 0.25
 
-const TRANSITION_SPEED_IN = 25
-const TRANSITION_SPEED_OUT = 15
-
 export var sprite : SpriteFrames
-export var target_pos = Vector2.ZERO
-export var move_to_scene = false
-export var scene_path : String
-
-var timer = 0
-var entering = false
-var can_warp = false
-var target = null
-var store_state = 0
-
-onready var sweep_effect = $"/root/Singleton/WindowWarp"
 
 func _ready():
 	$DoorSprite.frames = sprite
 
-func _physics_process(_delta):
-	if entering:
-		target.position.x = lerp(target.position.x, global_position.x, CENTERING_SPEED)
-		# Do entering animation
-		pass
+
+func _update_animation(_frame: int, _mario):
+	# Gradually center Mario
+	_mario.global_position.x = lerp(_mario.global_position.x, global_position.x, CENTERING_SPEED)
 	
-	if can_warp and target.locked == false:
-		# Begin entering door if up is pressed (while grounded + standing still)
-		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
-			# Set Mario to entering-door animation
-			target.locked = true
-			target.get_node("Character").set_animation("back")
-			
+	match _frame:
+		ENTER_BEGIN_TRANSITION:
+			#Play transition animation
+			return EnterState.CAN_TRANSITION
+		ENTER_LENGTH:
+			return EnterState.DONE
+		0:
+			# Start Mario's enter animation
+			_mario.get_node("Character").set_animation("back")
+			# Start door opening animation
 			$DoorSprite.play("opening")
-			can_warp = false
-			entering = true
-		
-		store_state = target.state # for next frame
-		
-	# Tick the animation timer
-	if entering == true:
-		timer += 1
-		
-	# Begin scene-change transition early if needed (looks better that way)
-	if timer == ENTER_LENGTH - TRANSITION_SPEED_IN and move_to_scene == true:
-		sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
-		
-	# If not changing scenes, warp Mario on timer ring
-	if timer == ENTER_LENGTH and move_to_scene != true:
-		# teleport Mario within the level
-		target.position = target_pos
-		
-		# reset Mario to normal
-		target.locked = false
-		
-		# Reset door to normal
-		timer = 0
-		entering = false
+			
+			return EnterState.ENTERING
+		_:
+			return EnterState.ENTERING
 
 
-func _on_mario_touch(body):
-	if body.state == body.S.NEUTRAL:
-		can_warp = true
-		target = body
-
-
-func _on_mario_off(_body):
-	if !entering: # w/o this check, target will get nulled when animation ends
-		can_warp = false # Or else he won't
-		target = null
+func _scene_transition(target_pos, scene_path):
+	# Default warp transition is a star iris.
+	var sweep_effect = $"/root/Singleton/WindowWarp"
+	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -3,10 +3,10 @@ extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
 
-export var doorGraphic : SpriteFrames
+export var door_graphic : SpriteFrames
 
 func _ready():
-	$DoorSprite.frames = doorGraphic
+	$DoorSprite.frames = door_graphic
 
 
 func _update_animation(_frame: int, _mario):

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -2,11 +2,12 @@ class_name Door
 extends Area2D
 
 const ENTER_LENGTH = 60
+const CENTERING_SPEED = 0.25
 
 const TRANSITION_SPEED_IN = 15
 const TRANSITION_SPEED_OUT = 15
 
-export var target_pos: Vector2
+export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
 
@@ -20,6 +21,7 @@ onready var sweep_effect = $"/root/Singleton/WindowWarp"
 
 func _physics_process(_delta):
 	if entering:
+		target.position.x = lerp(target.position.x, position.x, CENTERING_SPEED)
 		# Do entering animation
 		pass
 	
@@ -27,8 +29,12 @@ func _physics_process(_delta):
 		# Begin entering door if up is pressed (while grounded + standing still)
 		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			target.locked = true
+			
 			$DoorSprite.play("opening")
+			can_warp = false
 			entering = true
+		
+		store_state = target.state # for next frame
 		
 	# Tick the animation timer
 	if entering == true:
@@ -46,15 +52,19 @@ func _physics_process(_delta):
 			target.locked = false
 			
 			# Reset door to normal
+			timer = 0
 			entering = false
 
 
 func _on_mario_touch(body):
+	print_debug("Touched door")
 	if body.state == body.S.NEUTRAL:
 		can_warp = true
 		target = body
 
 
 func _on_mario_off(_body):
-	can_warp = false # Or else he won't
-	target = null
+	if !entering: # w/o this check, target will get nulled when animation ends
+		print_debug("left door")
+		can_warp = false # Or else he won't
+		target = null

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -28,6 +28,7 @@ func _physics_process(_delta):
 	if can_warp:
 		# Begin entering door if up is pressed (while grounded + standing still)
 		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
+			# Set Mario to entering-door animation
 			target.locked = true
 			
 			$DoorSprite.play("opening")
@@ -40,20 +41,21 @@ func _physics_process(_delta):
 	if entering == true:
 		timer += 1
 		
-	# When the timer rings, warp Mario
-	if timer == ENTER_LENGTH:
-		if move_to_scene == true:
-			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
-		else:
-			# teleport Mario within the level
-			target.position = target_pos
-			
-			# reset Mario to normal
-			target.locked = false
-			
-			# Reset door to normal
-			timer = 0
-			entering = false
+	# Begin scene-change transition early if needed (looks better that way)
+	if timer == ENTER_LENGTH - TRANSITION_SPEED_IN and move_to_scene == true:
+		sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+		
+	# If not changing scenes, warp Mario on timer ring
+	if timer == ENTER_LENGTH and move_to_scene != true:
+		# teleport Mario within the level
+		target.position = target_pos
+		
+		# reset Mario to normal
+		target.locked = false
+		
+		# Reset door to normal
+		timer = 0
+		entering = false
 
 
 func _on_mario_touch(body):

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,20 +1,33 @@
+tool
 class_name Door
 extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
 
-export var door_graphic : SpriteFrames
-export var player_fade_start_time : int = 20
-export var player_fade_rate : float = 0.1
-export var door_close_start_time : int = 20
+export var door_graphic : SpriteFrames setget set_door_graphic
+
+var player_fade_start_time : int
+var player_fade_rate : float
+var door_close_start_time : int
+
+func set_door_graphic(graphic : SpriteFrames):
+	door_graphic = graphic
+	
+	if door_graphic is DoorSkin:
+		# Resource has animation timings saved in it; load them.
+		player_fade_start_time = door_graphic.player_fade_start_time
+		player_fade_rate = door_graphic.player_fade_rate
+		door_close_start_time = door_graphic.door_close_start_time
+	else:
+		# Resource has no timings baked into it; use defaults.
+		player_fade_start_time = DoorSkin.DEFAULT_PLAYER_FADE_START
+		player_fade_rate = DoorSkin.DEFAULT_PLAYER_FADE_RATE
+		door_close_start_time = DoorSkin.DEFAULT_DOOR_CLOSE_START
+
 
 func _ready():
 	_set_sprite_frames(door_graphic)
-	
-	# Keep all export variables within sane ranges.
-	player_fade_start_time = max(player_fade_start_time, 0)
-	player_fade_rate = clamp(player_fade_rate, 0, 1)
-	door_close_start_time = max(door_close_start_time, 0)
+
 
 func _update_animation(_frame: int, _player):
 	# Gradually center the player

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -50,9 +50,9 @@ func _player_offset() -> int:
 func _player_begin_animation(player):
 	player.switch_anim("back")
 	# Set player to gradually move onto the door.
-	# NOTE: last I checked, this movement has a lerp factor of
-	# 0.75 per frame. Door entry feels smoother with a factor
-	# of 0.25 (more consistent with player movement).
+	# NOTE: read_pos_x movement currently has a lerp factor of 0.75 per frame.
+	# Door entry may feel smoother with a factor of 0.25
+	# (more consistent with player movement).
 	player.read_pos_x = global_position.x + _player_offset()
 
 

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,28 +1,60 @@
 class_name Door
-extends Interactable
+extends Area2D
+
+const ENTER_LENGTH = 60
+
+const TRANSITION_SPEED_IN = 15
+const TRANSITION_SPEED_OUT = 15
 
 export var target_pos: Vector2
 export var move_to_scene = false
-export var next_scene: PackedScene
+export var scene_path : String
 
 var timer = 0
-var entered = false
-var body_entering = null
+var entering = false
+var can_warp = false
+var target = null
+var store_state = 0
+
+onready var sweep_effect = $"/root/Singleton/WindowWarp"
 
 func _physics_process(_delta):
-	if entered == true:
+	if entering:
+		# Do entering animation
+		pass
+	
+	if can_warp:
+		# Begin entering door if up is pressed (while grounded + standing still)
+		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
+			target.locked = true
+			$DoorSprite.play("opening")
+			entering = true
+		
+	# Tick the animation timer
+	if entering == true:
 		timer += 1
-	if timer == 60:
+		
+	# When the timer rings, warp Mario
+	if timer == ENTER_LENGTH:
 		if move_to_scene == true:
-			# warning-ignore:return_value_discarded
-			get_tree().change_scene_to(next_scene)
-		body_entering.position = target_pos
-		body_entering.locked = false
-		entered = false
+			sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+		else:
+			# teleport Mario within the level
+			target.position = target_pos
+			
+			# reset Mario to normal
+			target.locked = false
+			
+			# Reset door to normal
+			entering = false
 
 
-func _interact_with(body) -> void:
-	body.locked = true
-	body_entering = body
-	sprite.play("opening")
-	entered = true
+func _on_mario_touch(body):
+	if body.state == body.S.NEUTRAL:
+		can_warp = true
+		target = body
+
+
+func _on_mario_off(_body):
+	can_warp = false # Or else he won't
+	target = null

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -4,7 +4,7 @@ extends Area2D
 const ENTER_LENGTH = 60
 const CENTERING_SPEED = 0.25
 
-const TRANSITION_SPEED_IN = 15
+const TRANSITION_SPEED_IN = 25
 const TRANSITION_SPEED_OUT = 15
 
 export var sprite : SpriteFrames

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -29,7 +29,7 @@ func _mario_offset() -> int:
 
 
 func _mario_begin_animation(mario):
-	mario.get_node("Character").set_animation("back")
+	mario.switch_anim("back")
 
 
 func _door_begin_animation():

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -11,13 +11,13 @@ func _ready():
 
 func _update_animation(_frame: int, _player):
 	# Gradually center the player
-	._player_shift_to_position(_player, global_position.x + _player_offset(), CENTERING_SPEED)
+	#._player_shift_to_position(_player, global_position.x + _player_offset(), CENTERING_SPEED)
 	
 	if _frame == 0:
-		# Start player's enter animation
-		_player_begin_animation(_player)
 		# Start door opening animation
 		_door_begin_animation()
+		# Start player's enter animation
+		_player_begin_animation(_player)
 
 
 func _animation_length():
@@ -30,6 +30,11 @@ func _player_offset() -> int:
 
 func _player_begin_animation(player):
 	player.switch_anim("back")
+	# Set player to gradually move onto the door.
+	# NOTE: last I checked, this movement has a lerp factor of
+	# 0.75 per frame. Door entry feels smoother with a factor
+	# of 0.25 (more consistent with player movement).
+	player.read_pos_x = global_position.x + _player_offset()
 
 
 func _door_begin_animation():

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -11,14 +11,26 @@ func _ready():
 
 func _update_animation(_frame: int, _mario):
 	# Gradually center Mario
-	_mario.global_position.x = lerp(_mario.global_position.x, global_position.x, CENTERING_SPEED)
+	._mario_shift_to_position(_mario, global_position.x + _mario_offset(), CENTERING_SPEED)
 	
 	if _frame == 0:
 		# Start Mario's enter animation
-		_mario.get_node("Character").set_animation("back")
+		_mario_begin_animation(_mario)
 		# Start door opening animation
-		$DoorSprite.play("opening")
+		_door_begin_animation()
 
 
 func _animation_length():
 	return 60
+
+
+func _mario_offset() -> int:
+	return 0
+
+
+func _mario_begin_animation(mario):
+	mario.get_node("Character").set_animation("back")
+
+
+func _door_begin_animation():
+	$DoorSprite.play("opening")

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -43,7 +43,7 @@ func _animation_length():
 	return 60
 
 
-func _enter_pos_offset() -> int:
+func _enter_pos_offset_x() -> int:
 	return 0
 
 
@@ -53,11 +53,12 @@ func _player_begin_animation(player):
 	# NOTE: read_pos_x movement currently has a lerp factor of 0.75 per frame.
 	# Door entry may feel smoother with a factor of 0.25
 	# (more consistent with player movement).
-	player.read_pos_x = global_position.x + _enter_pos_offset()
+	player.read_pos_x = global_position.x + _enter_pos_offset_x()
 
 
 func _door_open():
 	$Sprite.play("opening")
+
 
 func _door_close():
 	$Sprite.play("closing")

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -10,11 +10,11 @@ func _ready():
 
 
 func _update_animation(_frame: int, _player):
-	# Gradually center Mario
+	# Gradually center the player
 	._player_shift_to_position(_player, global_position.x + _player_offset(), CENTERING_SPEED)
 	
 	if _frame == 0:
-		# Start Mario's enter animation
+		# Start player's enter animation
 		_player_begin_animation(_player)
 		# Start door opening animation
 		_door_begin_animation()

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -25,7 +25,7 @@ func _physics_process(_delta):
 		# Do entering animation
 		pass
 	
-	if can_warp:
+	if can_warp and target.locked == false:
 		# Begin entering door if up is pressed (while grounded + standing still)
 		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			# Set Mario to entering-door animation

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -30,6 +30,7 @@ func _physics_process(_delta):
 		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			# Set Mario to entering-door animation
 			target.locked = true
+			target.get_node("Character").set_animation("back")
 			
 			$DoorSprite.play("opening")
 			can_warp = false

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -1,5 +1,5 @@
 class_name Door
-extends InteractableExit
+extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
 
@@ -18,6 +18,7 @@ func _update_animation(_frame: int, _mario):
 		_mario.get_node("Character").set_animation("back")
 		# Start door opening animation
 		$DoorSprite.play("opening")
+
 
 func _animation_length():
 	return 60

--- a/classes/interactable/door/door.gd
+++ b/classes/interactable/door/door.gd
@@ -2,15 +2,19 @@ class_name Door
 extends InteractableWarp
 
 const CENTERING_SPEED = 0.25
-const ANIM_PLAYER_BEGIN_FADEOUT = 8
-const ANIM_PLAYER_FADE_RATE = 0.1
-const ANIM_DOOR_BEGIN_CLOSE = 32
 
 export var door_graphic : SpriteFrames
+export var player_fade_start_time : int = 20
+export var player_fade_rate : float = 0.1
+export var door_close_start_time : int = 20
 
 func _ready():
 	_set_sprite_frames(door_graphic)
-
+	
+	# Keep all export variables within sane ranges.
+	player_fade_start_time = max(player_fade_start_time, 0)
+	player_fade_rate = clamp(player_fade_rate, 0, 1)
+	door_close_start_time = max(door_close_start_time, 0)
 
 func _update_animation(_frame: int, _player):
 	# Gradually center the player
@@ -21,10 +25,10 @@ func _update_animation(_frame: int, _player):
 		_door_open()
 		# Start player's enter animation
 		_player_begin_animation(_player)
-	if _frame >= ANIM_PLAYER_BEGIN_FADEOUT:
+	if _frame >= player_fade_start_time:
 		# Fade player down a little bit
-		_player.sprite.modulate.a -= ANIM_PLAYER_FADE_RATE
-	if _frame == ANIM_DOOR_BEGIN_CLOSE:
+		_player.sprite.modulate.a -= player_fade_rate
+	if _frame == door_close_start_time:
 		_door_close()
 	if _frame == _animation_length():
 		# Reset player to fully opaque

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -29,9 +29,6 @@ collision_mask = 2
 input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
-sprite = NodePath("DoorSprite")
-target_pos = null
-move_to_scene = null
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -29,6 +29,9 @@ collision_mask = 2
 input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
+target_pos = null
+move_to_scene = null
+scene_path = null
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -34,10 +34,12 @@ move_to_scene = null
 scene_path = null
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
+position = Vector2( 0, -16 )
 frames = SubResource( 1 )
 animation = "opening"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2( 0, -16 )
 shape = SubResource( 2 )
 
 [connection signal="body_entered" from="." to="." method="_on_mario_touch"]

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -30,14 +30,15 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
 sprite = NodePath("DoorSprite")
+target_pos = null
+move_to_scene = null
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )
 animation = "opening"
-frame = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
 
-[connection signal="body_entered" from="." to="." method="_on_Door_body_entered"]
-[connection signal="body_exited" from="." to="." method="_on_Door_body_exited"]
+[connection signal="body_entered" from="." to="." method="_on_mario_touch"]
+[connection signal="body_exited" from="." to="." method="_on_mario_off"]

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -29,14 +29,12 @@ collision_mask = 2
 input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
-target_pos = null
-move_to_scene = null
-scene_path = null
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
-position = Vector2( 0, -16 )
+position = Vector2( -8, -32 )
 frames = SubResource( 1 )
 animation = "opening"
+centered = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2( 0, -16 )

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -11,6 +11,8 @@ collision_mask = 2
 input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
+sprite = NodePath("DoorSprite")
+doorGraphic = ExtResource( 1 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 position = Vector2( -8, -32 )

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -12,7 +12,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
 sprite = NodePath("DoorSprite")
-doorGraphic = ExtResource( 1 )
+door_graphic = ExtResource( 1 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 position = Vector2( -8, -32 )
@@ -24,6 +24,3 @@ centered = false
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2( 0, -16 )
 shape = SubResource( 2 )
-
-[connection signal="body_entered" from="." to="." method="_on_mario_touch"]
-[connection signal="body_exited" from="." to="." method="_on_mario_off"]

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -14,6 +14,7 @@ script = ExtResource( 7 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 position = Vector2( -8, -32 )
+z_index = -1
 frames = ExtResource( 1 )
 animation = "opening"
 centered = false

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -1,25 +1,7 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://classes/interactable/door/door2.png" type="Texture" id=1]
-[ext_resource path="res://classes/interactable/door/door6.png" type="Texture" id=2]
-[ext_resource path="res://classes/interactable/door/door1.png" type="Texture" id=3]
-[ext_resource path="res://classes/interactable/door/door3.png" type="Texture" id=4]
-[ext_resource path="res://classes/interactable/door/door4.png" type="Texture" id=5]
-[ext_resource path="res://classes/interactable/door/door5.png" type="Texture" id=6]
+[ext_resource path="res://classes/interactable/door/skins/castle_door_diamond.tres" type="SpriteFrames" id=1]
 [ext_resource path="res://classes/interactable/door/door.gd" type="Script" id=7]
-
-[sub_resource type="SpriteFrames" id=1]
-animations = [ {
-"frames": [ ExtResource( 2 ), ExtResource( 6 ), ExtResource( 5 ), ExtResource( 4 ), ExtResource( 1 ), ExtResource( 3 ) ],
-"loop": false,
-"name": "closing",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 3 ), ExtResource( 1 ), ExtResource( 4 ), ExtResource( 5 ), ExtResource( 6 ), ExtResource( 2 ) ],
-"loop": false,
-"name": "opening",
-"speed": 10.0
-} ]
 
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 11, 15.9999 )
@@ -32,7 +14,7 @@ script = ExtResource( 7 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="."]
 position = Vector2( -8, -32 )
-frames = SubResource( 1 )
+frames = ExtResource( 1 )
 animation = "opening"
 centered = false
 

--- a/classes/interactable/door/door.tscn
+++ b/classes/interactable/door/door.tscn
@@ -11,10 +11,10 @@ collision_mask = 2
 input_pickable = false
 monitorable = false
 script = ExtResource( 7 )
-sprite = NodePath("DoorSprite")
+sprite = NodePath("Sprite")
 door_graphic = ExtResource( 1 )
 
-[node name="DoorSprite" type="AnimatedSprite" parent="."]
+[node name="Sprite" type="AnimatedSprite" parent="."]
 position = Vector2( -8, -32 )
 z_index = -1
 frames = ExtResource( 1 )

--- a/classes/interactable/door/door_skin.gd
+++ b/classes/interactable/door/door_skin.gd
@@ -1,0 +1,12 @@
+tool
+class_name DoorSkin
+extends SpriteFrames
+
+# Solid-choice fallback constants in case a skin is loaded with no script.
+const DEFAULT_PLAYER_FADE_START : int = 20
+const DEFAULT_PLAYER_FADE_RATE : float = 0.1
+const DEFAULT_DOOR_CLOSE_START : int = 20
+
+export (int, 0, 60) var player_fade_start_time = DEFAULT_PLAYER_FADE_START
+export (float, 0, 1, 0.1) var player_fade_rate = DEFAULT_PLAYER_FADE_RATE
+export (int, 0, 60) var door_close_start_time = DEFAULT_DOOR_CLOSE_START

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -26,7 +26,6 @@ animations = [ {
 extents = Vector2( 9.5, 15.9999 )
 
 [node name="Double Door" type="Node2D"]
-position = Vector2( 624, 392 )
 script = ExtResource( 2 )
 
 [node name="Door_L" type="Area2D" parent="."]
@@ -38,11 +37,11 @@ script = ExtResource( 8 )
 target_pos = Vector2( -8, 0 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="Door_L"]
-position = Vector2( -8, -32 )
+position = Vector2( 8, -32 )
+scale = Vector2( -1, 1 )
 frames = SubResource( 1 )
 animation = "opening"
 centered = false
-flip_h = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Door_L"]
 position = Vector2( -1.5, -16 )

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://classes/interactable/door/door.tscn" type="PackedScene" id=1]
+[ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
 
 [node name="Double Door" type="Node2D"]
 position = Vector2( 624, 392 )
+script = ExtResource( 2 )
 
 [node name="Door_L" parent="." instance=ExtResource( 1 )]
 position = Vector2( -8, 0 )

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,16 +1,72 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=11 format=2]
 
-[ext_resource path="res://classes/interactable/door/door.tscn" type="PackedScene" id=1]
+[ext_resource path="res://classes/interactable/door/door3.png" type="Texture" id=1]
 [ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
+[ext_resource path="res://classes/interactable/door/door4.png" type="Texture" id=3]
+[ext_resource path="res://classes/interactable/door/door5.png" type="Texture" id=4]
+[ext_resource path="res://classes/interactable/door/door1.png" type="Texture" id=5]
+[ext_resource path="res://classes/interactable/door/door2.png" type="Texture" id=6]
+[ext_resource path="res://classes/interactable/door/door6.png" type="Texture" id=7]
+[ext_resource path="res://classes/interactable/door/door.gd" type="Script" id=8]
+
+[sub_resource type="SpriteFrames" id=1]
+animations = [ {
+"frames": [ ExtResource( 7 ), ExtResource( 4 ), ExtResource( 3 ), ExtResource( 1 ), ExtResource( 6 ), ExtResource( 5 ) ],
+"loop": false,
+"name": "closing",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 5 ), ExtResource( 6 ), ExtResource( 1 ), ExtResource( 3 ), ExtResource( 4 ), ExtResource( 7 ) ],
+"loop": false,
+"name": "opening",
+"speed": 10.0
+} ]
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 9.5, 15.9999 )
 
 [node name="Double Door" type="Node2D"]
 position = Vector2( 624, 392 )
 script = ExtResource( 2 )
 
-[node name="Door_L" parent="." instance=ExtResource( 1 )]
+[node name="Door_L" type="Area2D" parent="."]
 position = Vector2( -8, 0 )
+collision_mask = 2
+input_pickable = false
+monitorable = false
+script = ExtResource( 8 )
 target_pos = Vector2( -8, 0 )
 
-[node name="Door_R" parent="." instance=ExtResource( 1 )]
+[node name="DoorSprite" type="AnimatedSprite" parent="Door_L"]
+position = Vector2( -8, -32 )
+frames = SubResource( 1 )
+animation = "opening"
+centered = false
+flip_h = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Door_L"]
+position = Vector2( -1.5, -16 )
+shape = SubResource( 2 )
+
+[node name="Door_R" type="Area2D" parent="."]
 position = Vector2( 8, 0 )
+collision_mask = 2
+input_pickable = false
+monitorable = false
+script = ExtResource( 8 )
 target_pos = Vector2( 8, 0 )
+
+[node name="DoorSprite" type="AnimatedSprite" parent="Door_R"]
+position = Vector2( -8, -32 )
+frames = SubResource( 1 )
+animation = "opening"
+centered = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Door_R"]
+position = Vector2( 1.5, -16 )
+shape = SubResource( 2 )
+
+[connection signal="body_entered" from="Door_L" to="Door_L" method="_on_mario_touch"]
+[connection signal="body_exited" from="Door_L" to="Door_L" method="_on_mario_off"]
+[connection signal="body_entered" from="Door_R" to="Door_R" method="_on_mario_touch"]
+[connection signal="body_exited" from="Door_R" to="Door_R" method="_on_mario_off"]

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,56 +1,32 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://classes/interactable/door/skins/castle_door_diamond.tres" type="SpriteFrames" id=1]
 [ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
-[ext_resource path="res://classes/interactable/door/door.gd" type="Script" id=8]
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 7, 15.9999 )
+extents = Vector2( 19, 15.9999 )
 
-[node name="Double Door" type="Node2D"]
+[node name="Double Door" type="Area2D"]
 script = ExtResource( 2 )
-sprite = ExtResource( 1 )
+sprite = NodePath("SpriteL")
+door_graphic = ExtResource( 1 )
 
-[node name="Door_L" type="Area2D" parent="."]
-position = Vector2( -8, 0 )
-collision_mask = 2
-input_pickable = false
-monitorable = false
-script = ExtResource( 8 )
-target_pos = Vector2( -8, 0 )
-
-[node name="DoorSprite" type="AnimatedSprite" parent="Door_L"]
-position = Vector2( 8, -32 )
-scale = Vector2( -1, 1 )
+[node name="SpriteL" type="AnimatedSprite" parent="."]
+position = Vector2( 0, -32 )
+rotation = 3.14159
+scale = Vector2( 1, -1 )
 z_index = -1
 frames = ExtResource( 1 )
 animation = "opening"
 centered = false
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Door_L"]
-position = Vector2( -4, -16 )
-shape = SubResource( 2 )
-
-[node name="Door_R" type="Area2D" parent="."]
-position = Vector2( 8, 0 )
-collision_mask = 2
-input_pickable = false
-monitorable = false
-script = ExtResource( 8 )
-target_pos = Vector2( 8, 0 )
-
-[node name="DoorSprite" type="AnimatedSprite" parent="Door_R"]
-position = Vector2( -8, -32 )
+[node name="SpriteR" type="AnimatedSprite" parent="."]
+position = Vector2( 0, -32 )
 z_index = -1
 frames = ExtResource( 1 )
 animation = "opening"
 centered = false
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Door_R"]
-position = Vector2( 4, -16 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2( 0, -16 )
 shape = SubResource( 2 )
-
-[connection signal="body_entered" from="Door_L" to="Door_L" method="_on_mario_touch"]
-[connection signal="body_exited" from="Door_L" to="Door_L" method="_on_mario_off"]
-[connection signal="body_entered" from="Door_R" to="Door_R" method="_on_mario_touch"]
-[connection signal="body_exited" from="Door_R" to="Door_R" method="_on_mario_off"]

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://classes/interactable/door/door.tscn" type="PackedScene" id=1]
+[ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
+
+[node name="Double Door" type="Node2D"]
+position = Vector2( 624, 392 )
+script = ExtResource( 2 )
+scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"
+
+[node name="Door_L" parent="." instance=ExtResource( 1 )]
+position = Vector2( -8, 0 )
+target_pos = Vector2( -8, 0 )
+move_to_scene = false
+scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"
+
+[node name="Door_R" parent="." instance=ExtResource( 1 )]
+position = Vector2( 8, 0 )
+target_pos = Vector2( 8, 0 )
+move_to_scene = false
+scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,21 +1,14 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://classes/interactable/door/door.tscn" type="PackedScene" id=1]
-[ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
 
 [node name="Double Door" type="Node2D"]
 position = Vector2( 624, 392 )
-script = ExtResource( 2 )
-scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"
 
 [node name="Door_L" parent="." instance=ExtResource( 1 )]
 position = Vector2( -8, 0 )
 target_pos = Vector2( -8, 0 )
-move_to_scene = false
-scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"
 
 [node name="Door_R" parent="." instance=ExtResource( 1 )]
 position = Vector2( 8, 0 )
 target_pos = Vector2( 8, 0 )
-move_to_scene = false
-scene_path = "res://scenes/levels/tutorial_1/tutorial_1_1.tscn"

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -7,6 +7,7 @@
 extents = Vector2( 19, 15.9999 )
 
 [node name="DoubleDoor" type="Area2D"]
+monitorable = false
 script = ExtResource( 2 )
 sprite = NodePath("SpriteL")
 door_graphic = ExtResource( 1 )

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -6,7 +6,7 @@
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 19, 15.9999 )
 
-[node name="Double Door" type="Area2D"]
+[node name="DoubleDoor" type="Area2D"]
 script = ExtResource( 2 )
 sprite = NodePath("SpriteL")
 door_graphic = ExtResource( 1 )

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -1,32 +1,15 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://classes/interactable/door/door3.png" type="Texture" id=1]
+[ext_resource path="res://classes/interactable/door/skins/castle_door_diamond.tres" type="SpriteFrames" id=1]
 [ext_resource path="res://classes/interactable/door/double_doors.gd" type="Script" id=2]
-[ext_resource path="res://classes/interactable/door/door4.png" type="Texture" id=3]
-[ext_resource path="res://classes/interactable/door/door5.png" type="Texture" id=4]
-[ext_resource path="res://classes/interactable/door/door1.png" type="Texture" id=5]
-[ext_resource path="res://classes/interactable/door/door2.png" type="Texture" id=6]
-[ext_resource path="res://classes/interactable/door/door6.png" type="Texture" id=7]
 [ext_resource path="res://classes/interactable/door/door.gd" type="Script" id=8]
 
-[sub_resource type="SpriteFrames" id=1]
-animations = [ {
-"frames": [ ExtResource( 7 ), ExtResource( 4 ), ExtResource( 3 ), ExtResource( 1 ), ExtResource( 6 ), ExtResource( 5 ) ],
-"loop": false,
-"name": "closing",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 5 ), ExtResource( 6 ), ExtResource( 1 ), ExtResource( 3 ), ExtResource( 4 ), ExtResource( 7 ) ],
-"loop": false,
-"name": "opening",
-"speed": 10.0
-} ]
-
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 9.5, 15.9999 )
+extents = Vector2( 7, 15.9999 )
 
 [node name="Double Door" type="Node2D"]
 script = ExtResource( 2 )
+sprite = ExtResource( 1 )
 
 [node name="Door_L" type="Area2D" parent="."]
 position = Vector2( -8, 0 )
@@ -39,12 +22,12 @@ target_pos = Vector2( -8, 0 )
 [node name="DoorSprite" type="AnimatedSprite" parent="Door_L"]
 position = Vector2( 8, -32 )
 scale = Vector2( -1, 1 )
-frames = SubResource( 1 )
+frames = ExtResource( 1 )
 animation = "opening"
 centered = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Door_L"]
-position = Vector2( -1.5, -16 )
+position = Vector2( -4, -16 )
 shape = SubResource( 2 )
 
 [node name="Door_R" type="Area2D" parent="."]
@@ -57,12 +40,12 @@ target_pos = Vector2( 8, 0 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="Door_R"]
 position = Vector2( -8, -32 )
-frames = SubResource( 1 )
+frames = ExtResource( 1 )
 animation = "opening"
 centered = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Door_R"]
-position = Vector2( 1.5, -16 )
+position = Vector2( 4, -16 )
 shape = SubResource( 2 )
 
 [connection signal="body_entered" from="Door_L" to="Door_L" method="_on_mario_touch"]

--- a/classes/interactable/door/double_door.tscn
+++ b/classes/interactable/door/double_door.tscn
@@ -22,6 +22,7 @@ target_pos = Vector2( -8, 0 )
 [node name="DoorSprite" type="AnimatedSprite" parent="Door_L"]
 position = Vector2( 8, -32 )
 scale = Vector2( -1, 1 )
+z_index = -1
 frames = ExtResource( 1 )
 animation = "opening"
 centered = false
@@ -40,6 +41,7 @@ target_pos = Vector2( 8, 0 )
 
 [node name="DoorSprite" type="AnimatedSprite" parent="Door_R"]
 position = Vector2( -8, -32 )
+z_index = -1
 frames = ExtResource( 1 )
 animation = "opening"
 centered = false

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -13,7 +13,7 @@ func _set_sprite_frames(sprite_frames: SpriteFrames):
 	$SpriteR.frames = sprite_frames
 
 
-func _player_offset() -> int:
+func _enter_pos_offset() -> int:
 	return SINGLE_DOOR_OFFSET * chosen_side
 
 
@@ -52,8 +52,4 @@ func _door_close():
 func _begin_scene_change(target_pos, scene_path):
 	# Clobber the destination position so player comes out on the left or right.
 	# TODO: Figure out how to do this during in-scene warps.
-	._begin_scene_change(target_pos + chosen_door_offset(), scene_path)
-
-
-func chosen_door_offset() -> Vector2:
-	return Vector2(_player_offset(), 0)
+	._begin_scene_change(target_pos + Vector2(_enter_pos_offset(), 0), scene_path)

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -27,6 +27,9 @@ func _door_begin_animation():
 		should_use_right_door = player.global_position.x > (global_position.x - FACING_BIAS)
 	else:
 		# Player is facing left.
+		# Comparison operator is different than when facing right--
+		# this is intentional, because it shifts the comparison
+		# over by one unit.
 		should_use_right_door = player.global_position.x >= (global_position.x + FACING_BIAS)
 		
 		

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -7,8 +7,8 @@ export var target_pos = Vector2.ZERO setget set_target_pos, get_target_pos
 export var move_to_scene = false setget set_move_to_scene, get_move_to_scene
 export var scene_path : String setget set_scene_path, get_scene_path
 
-onready var door_l : Door
-onready var door_r : Door
+onready var door_l : Door = $Door_L
+onready var door_r : Door = $Door_R
 
 
 func set_target_pos(val):
@@ -36,6 +36,7 @@ func set_scene_path(val):
 
 
 func get_target_pos():
+	door_l = $Door_L
 	return door_l.target_pos + SINGLE_DOOR_OFFSET
 
 

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,8 +1,8 @@
-tool
 extends Node2D
 
 const SINGLE_DOOR_OFFSET = Vector2(8,0)
 
+export var sprite : SpriteFrames
 export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
@@ -11,10 +11,13 @@ onready var door_l : Door = $Door_L
 onready var door_r : Door = $Door_R
 
 func _ready():
-	#When run in game, populate child doors with my data
+	# When run in game, populate child doors with my data
 	if !Engine.editor_hint:
 		door_l = $Door_L
 		door_r = $Door_R
+		
+		$Door_L/DoorSprite.frames = sprite
+		$Door_R/DoorSprite.frames = sprite
 		
 		door_l.target_pos = target_pos - SINGLE_DOOR_OFFSET
 		door_r.target_pos = target_pos + SINGLE_DOOR_OFFSET
@@ -24,3 +27,4 @@ func _ready():
 		
 		door_l.scene_path = scene_path
 		door_r.scene_path = scene_path
+

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -8,9 +8,9 @@ const FACING_BIAS = 2 # If Mario's facing one door, he can enter it this many pi
 # a door, meaning we can't rely on "is he left of the doors' origin?"
 var chosen_side = 0
 
-func _ready():
-	$SpriteL.frames = door_graphic
-	$SpriteR.frames = door_graphic
+func _set_sprite_frames(sprite_frames: SpriteFrames):
+	$SpriteL.frames = sprite_frames
+	$SpriteR.frames = sprite_frames
 
 
 func _mario_offset() -> int:

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,64 +1,47 @@
-extends InteractableWarp
+extends Door
 
-const CENTERING_SPEED = Door.CENTERING_SPEED
 const SINGLE_DOOR_OFFSET = 8
 const FACING_BIAS = 2 # If Mario's facing one door, he can enter it this many pixels further away.
-
-export var door_graphic : SpriteFrames
 
 # This stores which side we've chosen to enter.
 # We need this because Mario's facing direction shifts as he enters
 # a door, meaning we can't rely on "is he left of the doors' origin?"
 var chosen_side = 0
 
-func _draw():
-	# For debugging, render the split point for which door Mario will enter.
-	draw_line(global_position + mario_offset(),
-		global_position + mario_offset() + Vector2(0, 2),
-		Color(0.1, 1.0, 0.2))
-
 func _ready():
 	$SpriteL.frames = door_graphic
 	$SpriteR.frames = door_graphic
 
 
-func _update_animation(_frame: int, _mario):
-	# Gradually center Mario over one of the doors
-	_mario.global_position.x = lerp(_mario.global_position.x,
-		global_position.x + mario_offset().x, CENTERING_SPEED)
-	
-	if _frame == 0:
-		# Start Mario's enter animation
-		_mario.get_node("Character").set_animation("back")
-		# Start door opening animation on the appropriate door
-		if should_use_right_door() == true:
-			$SpriteR.play("opening")
-			chosen_side = 1
-		else:
-			$SpriteL.play("opening")
-			chosen_side = -1
+func _mario_offset() -> int:
+	return SINGLE_DOOR_OFFSET * chosen_side
 
 
-func _animation_length():
-	return 60
-
-
-func _begin_scene_change(target_pos, scene_path):
-	# Clobber the destination position so Mario comes out on the left or right.
-	._begin_scene_change(target_pos + mario_offset(), scene_path)
-
-
-func mario_offset() -> Vector2:
-	return Vector2(SINGLE_DOOR_OFFSET * chosen_side, 0)
-
-
-func should_use_right_door() -> bool:
-	# Broadly, this checks if Mario is to the right or left of the center.
+func _door_begin_animation():
+	var should_use_right_door = false
+	# Check if Mario is to the right or left of the center.
 	# BUT--if Mario is facing one direction or another, he'll be SLIGHTLY more
 	# receptive to using the door he's facing towards.
 	if mario.sprite.flip_h == false:
 		# Mario facing right.
-		return mario.global_position.x > (global_position.x - FACING_BIAS)
+		should_use_right_door = mario.global_position.x > (global_position.x - FACING_BIAS)
 	else:
 		# Mario facing left.
-		return mario.global_position.x >= (global_position.x + FACING_BIAS)
+		should_use_right_door = mario.global_position.x >= (global_position.x + FACING_BIAS)
+		
+		
+	if should_use_right_door == true:
+		$SpriteR.play("opening")
+		chosen_side = 1
+	else:
+		$SpriteL.play("opening")
+		chosen_side = -1
+
+
+func _begin_scene_change(target_pos, scene_path):
+	# Clobber the destination position so Mario comes out on the left or right.
+	._begin_scene_change(target_pos + chosen_door_offset(), scene_path)
+
+
+func chosen_door_offset() -> Vector2:
+	return Vector2(_mario_offset(), 0)

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -13,7 +13,7 @@ func _set_sprite_frames(sprite_frames: SpriteFrames):
 	$SpriteR.frames = sprite_frames
 
 
-func _mario_offset() -> int:
+func _player_offset() -> int:
 	return SINGLE_DOOR_OFFSET * chosen_side
 
 
@@ -22,12 +22,12 @@ func _door_begin_animation():
 	# Check if Mario is to the right or left of the center.
 	# BUT--if Mario is facing one direction or another, he'll be SLIGHTLY more
 	# receptive to using the door he's facing towards.
-	if mario.sprite.flip_h == false:
+	if player.sprite.flip_h == false:
 		# Mario facing right.
-		should_use_right_door = mario.global_position.x > (global_position.x - FACING_BIAS)
+		should_use_right_door = player.global_position.x > (global_position.x - FACING_BIAS)
 	else:
 		# Mario facing left.
-		should_use_right_door = mario.global_position.x >= (global_position.x + FACING_BIAS)
+		should_use_right_door = player.global_position.x >= (global_position.x + FACING_BIAS)
 		
 		
 	if should_use_right_door == true:
@@ -44,4 +44,4 @@ func _begin_scene_change(target_pos, scene_path):
 
 
 func chosen_door_offset() -> Vector2:
-	return Vector2(_mario_offset(), 0)
+	return Vector2(_player_offset(), 0)

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -3,6 +3,8 @@ extends Door
 const SINGLE_DOOR_OFFSET = 8
 const FACING_BIAS = 2 # If player's facing one door, they can enter it this many pixels further away.
 
+export var force_exact_target = false
+
 # This stores which side we've chosen to enter.
 # We need this because the player's facing direction shifts as they enter
 # a door, meaning we can't rely on "are they left of the doors' origin?"
@@ -18,7 +20,7 @@ func _enter_pos_offset_x() -> int:
 
 
 func _exit_pos_offset() -> Vector2:
-	return Vector2(_enter_pos_offset_x(), 0)
+	return Vector2(_enter_pos_offset_x(), 0) if !force_exact_target else Vector2(0,0)
 
 
 func _door_open():

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -10,6 +10,7 @@ export var force_exact_target = false
 # a door, meaning we can't rely on "are they left of the doors' origin?"
 var chosen_side = 0
 
+
 func _set_sprite_frames(sprite_frames: SpriteFrames):
 	$SpriteL.frames = sprite_frames
 	$SpriteR.frames = sprite_frames
@@ -20,7 +21,10 @@ func _enter_pos_offset_x() -> int:
 
 
 func _exit_pos_offset() -> Vector2:
-	return Vector2(_enter_pos_offset_x(), 0) if !force_exact_target else Vector2(0,0)
+	if force_exact_target:
+		return Vector2(0,0)
+	else:
+		return Vector2(_enter_pos_offset_x(), 0)
 
 
 func _door_open():

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,11 +1,11 @@
 extends Door
 
 const SINGLE_DOOR_OFFSET = 8
-const FACING_BIAS = 2 # If Mario's facing one door, he can enter it this many pixels further away.
+const FACING_BIAS = 2 # If player's facing one door, they can enter it this many pixels further away.
 
 # This stores which side we've chosen to enter.
-# We need this because Mario's facing direction shifts as he enters
-# a door, meaning we can't rely on "is he left of the doors' origin?"
+# We need this because the player's facing direction shifts as they enter
+# a door, meaning we can't rely on "are they left of the doors' origin?"
 var chosen_side = 0
 
 func _set_sprite_frames(sprite_frames: SpriteFrames):
@@ -19,14 +19,14 @@ func _player_offset() -> int:
 
 func _door_begin_animation():
 	var should_use_right_door = false
-	# Check if Mario is to the right or left of the center.
-	# BUT--if Mario is facing one direction or another, he'll be SLIGHTLY more
-	# receptive to using the door he's facing towards.
+	# Check if player is to the right or left of the center.
+	# BUT--if player is facing one direction or another, be SLIGHTLY more
+	# receptive to using the door they're facing towards.
 	if player.sprite.flip_h == false:
-		# Mario facing right.
+		# Player is facing right.
 		should_use_right_door = player.global_position.x > (global_position.x - FACING_BIAS)
 	else:
-		# Mario facing left.
+		# Player is facing left.
 		should_use_right_door = player.global_position.x >= (global_position.x + FACING_BIAS)
 		
 		
@@ -39,7 +39,8 @@ func _door_begin_animation():
 
 
 func _begin_scene_change(target_pos, scene_path):
-	# Clobber the destination position so Mario comes out on the left or right.
+	# Clobber the destination position so player comes out on the left or right.
+	# TODO: Figure out how to do this during non-scene-changes.
 	._begin_scene_change(target_pos + chosen_door_offset(), scene_path)
 
 

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -13,8 +13,12 @@ func _set_sprite_frames(sprite_frames: SpriteFrames):
 	$SpriteR.frames = sprite_frames
 
 
-func _enter_pos_offset() -> int:
+func _enter_pos_offset_x() -> int:
 	return SINGLE_DOOR_OFFSET * chosen_side
+
+
+func _exit_pos_offset() -> Vector2:
+	return Vector2(_enter_pos_offset_x(), 0)
 
 
 func _door_open():
@@ -47,9 +51,3 @@ func _door_close():
 		$SpriteR.play("closing")
 	else:
 		$SpriteL.play("closing")
-
-
-func _begin_scene_change(target_pos, scene_path):
-	# Clobber the destination position so player comes out on the left or right.
-	# TODO: Figure out how to do this during in-scene warps.
-	._begin_scene_change(target_pos + Vector2(_enter_pos_offset(), 0), scene_path)

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,30 +1,64 @@
-extends Node2D
+extends InteractableWarp
 
-const SINGLE_DOOR_OFFSET = Vector2(8,0)
+const CENTERING_SPEED = Door.CENTERING_SPEED
+const SINGLE_DOOR_OFFSET = 8
+const FACING_BIAS = 2 # If Mario's facing one door, he can enter it this many pixels further away.
 
-export var sprite : SpriteFrames
-export var target_pos = Vector2.ZERO
-export var move_to_scene = false
-export var scene_path : String
+export var door_graphic : SpriteFrames
 
-onready var door_l : Door = $Door_L
-onready var door_r : Door = $Door_R
+# This stores which side we've chosen to enter.
+# We need this because Mario's facing direction shifts as he enters
+# a door, meaning we can't rely on "is he left of the doors' origin?"
+var chosen_side = 0
+
+func _draw():
+	# For debugging, render the split point for which door Mario will enter.
+	draw_line(global_position + mario_offset(),
+		global_position + mario_offset() + Vector2(0, 2),
+		Color(0.1, 1.0, 0.2))
 
 func _ready():
-	# When run in game, populate child doors with my data
-	if !Engine.editor_hint:
-		door_l = $Door_L
-		door_r = $Door_R
-		
-		$Door_L/DoorSprite.frames = sprite
-		$Door_R/DoorSprite.frames = sprite
-		
-		door_l.target_pos = target_pos - SINGLE_DOOR_OFFSET
-		door_r.target_pos = target_pos + SINGLE_DOOR_OFFSET
-		
-		door_l.move_to_scene = move_to_scene
-		door_r.move_to_scene = move_to_scene
-		
-		door_l.scene_path = scene_path
-		door_r.scene_path = scene_path
+	$SpriteL.frames = door_graphic
+	$SpriteR.frames = door_graphic
 
+
+func _update_animation(_frame: int, _mario):
+	# Gradually center Mario over one of the doors
+	_mario.global_position.x = lerp(_mario.global_position.x,
+		global_position.x + mario_offset().x, CENTERING_SPEED)
+	
+	if _frame == 0:
+		# Start Mario's enter animation
+		_mario.get_node("Character").set_animation("back")
+		# Start door opening animation on the appropriate door
+		if should_use_right_door() == true:
+			$SpriteR.play("opening")
+			chosen_side = 1
+		else:
+			$SpriteL.play("opening")
+			chosen_side = -1
+
+
+func _animation_length():
+	return 60
+
+
+func _begin_scene_change(target_pos, scene_path):
+	# Clobber the destination position so Mario comes out on the left or right.
+	._begin_scene_change(target_pos + mario_offset(), scene_path)
+
+
+func mario_offset() -> Vector2:
+	return Vector2(SINGLE_DOOR_OFFSET * chosen_side, 0)
+
+
+func should_use_right_door() -> bool:
+	# Broadly, this checks if Mario is to the right or left of the center.
+	# BUT--if Mario is facing one direction or another, he'll be SLIGHTLY more
+	# receptive to using the door he's facing towards.
+	if mario.sprite.flip_h == false:
+		# Mario facing right.
+		return mario.global_position.x > (global_position.x - FACING_BIAS)
+	else:
+		# Mario facing left.
+		return mario.global_position.x >= (global_position.x + FACING_BIAS)

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -17,7 +17,7 @@ func _player_offset() -> int:
 	return SINGLE_DOOR_OFFSET * chosen_side
 
 
-func _door_begin_animation():
+func _door_open():
 	var should_use_right_door = false
 	# Check if player is to the right or left of the center.
 	# BUT--if player is facing one direction or another, be SLIGHTLY more
@@ -41,9 +41,17 @@ func _door_begin_animation():
 		chosen_side = -1
 
 
+func _door_close():
+	# Close whichever door was opened.
+	if chosen_side == 1:
+		$SpriteR.play("closing")
+	else:
+		$SpriteL.play("closing")
+
+
 func _begin_scene_change(target_pos, scene_path):
 	# Clobber the destination position so player comes out on the left or right.
-	# TODO: Figure out how to do this during non-scene-changes.
+	# TODO: Figure out how to do this during in-scene warps.
 	._begin_scene_change(target_pos + chosen_door_offset(), scene_path)
 
 

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,0 +1,38 @@
+tool
+extends Node2D
+
+const SINGLE_DOOR_OFFSET = 8
+
+export var target_pos = Vector2.ZERO setget set_target_pos, get_target_pos
+export var move_to_scene = false setget set_move_to_scene, get_move_to_scene
+export var scene_path : String setget set_scene_path, get_scene_path
+
+onready var door_l = $"Door L"
+onready var door_r = $"Door_R"
+
+
+func set_target_pos(val):
+	door_l.target_pos.x = val.x - SINGLE_DOOR_OFFSET
+	door_r.target_pos.x = val.x + SINGLE_DOOR_OFFSET
+
+
+func set_move_to_scene(val):
+	door_l.move_to_scene = val
+	door_r.move_to_scene = val
+
+
+func set_scene_path(val):
+	door_l.scene_path = val
+	door_r.scene_path = val
+
+
+func get_target_pos():
+	return door_l.target_pos + Vector2(SINGLE_DOOR_OFFSET,0)
+
+
+func get_move_to_scene():
+	return door_l.move_to_scene
+
+
+func get_scene_path():
+	return door_l.scene_path

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -1,38 +1,49 @@
 tool
 extends Node2D
 
-const SINGLE_DOOR_OFFSET = 8
+const SINGLE_DOOR_OFFSET = Vector2(8,0)
 
 export var target_pos = Vector2.ZERO setget set_target_pos, get_target_pos
 export var move_to_scene = false setget set_move_to_scene, get_move_to_scene
 export var scene_path : String setget set_scene_path, get_scene_path
 
-onready var door_l = $"Door L"
-onready var door_r = $"Door_R"
+onready var door_l : Door
+onready var door_r : Door
 
 
 func set_target_pos(val):
-	door_l.target_pos.x = val.x - SINGLE_DOOR_OFFSET
-	door_r.target_pos.x = val.x + SINGLE_DOOR_OFFSET
+	door_l = $Door_L
+	door_r = $Door_R
+	
+	door_l.target_pos = val - SINGLE_DOOR_OFFSET
+	door_r.target_pos = val + SINGLE_DOOR_OFFSET
 
 
 func set_move_to_scene(val):
+	door_l = $Door_L
+	door_r = $Door_R
+	
 	door_l.move_to_scene = val
 	door_r.move_to_scene = val
 
 
 func set_scene_path(val):
+	door_l = $Door_L
+	door_r = $Door_R
+	
 	door_l.scene_path = val
 	door_r.scene_path = val
 
 
 func get_target_pos():
-	return door_l.target_pos + Vector2(SINGLE_DOOR_OFFSET,0)
+	return door_l.target_pos + SINGLE_DOOR_OFFSET
 
 
 func get_move_to_scene():
+	door_l = $Door_L
 	return door_l.move_to_scene
 
 
 func get_scene_path():
+	door_l = $Door_L
 	return door_l.scene_path

--- a/classes/interactable/door/double_doors.gd
+++ b/classes/interactable/door/double_doors.gd
@@ -3,48 +3,24 @@ extends Node2D
 
 const SINGLE_DOOR_OFFSET = Vector2(8,0)
 
-export var target_pos = Vector2.ZERO setget set_target_pos, get_target_pos
-export var move_to_scene = false setget set_move_to_scene, get_move_to_scene
-export var scene_path : String setget set_scene_path, get_scene_path
+export var target_pos = Vector2.ZERO
+export var move_to_scene = false
+export var scene_path : String
 
 onready var door_l : Door = $Door_L
 onready var door_r : Door = $Door_R
 
-
-func set_target_pos(val):
-	door_l = $Door_L
-	door_r = $Door_R
-	
-	door_l.target_pos = val - SINGLE_DOOR_OFFSET
-	door_r.target_pos = val + SINGLE_DOOR_OFFSET
-
-
-func set_move_to_scene(val):
-	door_l = $Door_L
-	door_r = $Door_R
-	
-	door_l.move_to_scene = val
-	door_r.move_to_scene = val
-
-
-func set_scene_path(val):
-	door_l = $Door_L
-	door_r = $Door_R
-	
-	door_l.scene_path = val
-	door_r.scene_path = val
-
-
-func get_target_pos():
-	door_l = $Door_L
-	return door_l.target_pos + SINGLE_DOOR_OFFSET
-
-
-func get_move_to_scene():
-	door_l = $Door_L
-	return door_l.move_to_scene
-
-
-func get_scene_path():
-	door_l = $Door_L
-	return door_l.scene_path
+func _ready():
+	#When run in game, populate child doors with my data
+	if !Engine.editor_hint:
+		door_l = $Door_L
+		door_r = $Door_R
+		
+		door_l.target_pos = target_pos - SINGLE_DOOR_OFFSET
+		door_r.target_pos = target_pos + SINGLE_DOOR_OFFSET
+		
+		door_l.move_to_scene = move_to_scene
+		door_r.move_to_scene = move_to_scene
+		
+		door_l.scene_path = scene_path
+		door_r.scene_path = scene_path

--- a/classes/interactable/door/skins/castle_door_diamond.tres
+++ b/classes/interactable/door/skins/castle_door_diamond.tres
@@ -1,0 +1,22 @@
+[gd_resource type="SpriteFrames" load_steps=7 format=2]
+
+[ext_resource path="res://classes/interactable/door/door3.png" type="Texture" id=1]
+[ext_resource path="res://classes/interactable/door/door4.png" type="Texture" id=2]
+[ext_resource path="res://classes/interactable/door/door5.png" type="Texture" id=3]
+[ext_resource path="res://classes/interactable/door/door1.png" type="Texture" id=4]
+[ext_resource path="res://classes/interactable/door/door2.png" type="Texture" id=5]
+[ext_resource path="res://classes/interactable/door/door6.png" type="Texture" id=6]
+
+[resource]
+resource_name = "Castle Door Diamond"
+animations = [ {
+"frames": [ ExtResource( 6 ), ExtResource( 3 ), ExtResource( 2 ), ExtResource( 1 ), ExtResource( 5 ), ExtResource( 4 ) ],
+"loop": false,
+"name": "closing",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 4 ), ExtResource( 5 ), ExtResource( 1 ), ExtResource( 2 ), ExtResource( 3 ), ExtResource( 6 ) ],
+"loop": false,
+"name": "opening",
+"speed": 10.0
+} ]

--- a/classes/interactable/door/skins/castle_door_diamond.tres
+++ b/classes/interactable/door/skins/castle_door_diamond.tres
@@ -13,10 +13,10 @@ animations = [ {
 "frames": [ ExtResource( 6 ), ExtResource( 3 ), ExtResource( 2 ), ExtResource( 1 ), ExtResource( 5 ), ExtResource( 4 ) ],
 "loop": false,
 "name": "closing",
-"speed": 10.0
+"speed": 20.0
 }, {
 "frames": [ ExtResource( 4 ), ExtResource( 5 ), ExtResource( 1 ), ExtResource( 2 ), ExtResource( 3 ), ExtResource( 6 ) ],
 "loop": false,
 "name": "opening",
-"speed": 10.0
+"speed": 30.0
 } ]

--- a/classes/interactable/door/skins/castle_door_diamond.tres
+++ b/classes/interactable/door/skins/castle_door_diamond.tres
@@ -1,4 +1,4 @@
-[gd_resource type="SpriteFrames" load_steps=7 format=2]
+[gd_resource type="SpriteFrames" load_steps=8 format=2]
 
 [ext_resource path="res://classes/interactable/door/door3.png" type="Texture" id=1]
 [ext_resource path="res://classes/interactable/door/door4.png" type="Texture" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://classes/interactable/door/door1.png" type="Texture" id=4]
 [ext_resource path="res://classes/interactable/door/door2.png" type="Texture" id=5]
 [ext_resource path="res://classes/interactable/door/door6.png" type="Texture" id=6]
+[ext_resource path="res://classes/interactable/door/door_skin.gd" type="Script" id=7]
 
 [resource]
 resource_name = "Castle Door Diamond"
@@ -20,3 +21,7 @@ animations = [ {
 "name": "opening",
 "speed": 30.0
 } ]
+script = ExtResource( 7 )
+player_fade_start_time = 20
+player_fade_rate = 0.1
+door_close_start_time = 20

--- a/classes/interactable/interactable_exit.gd
+++ b/classes/interactable/interactable_exit.gd
@@ -1,0 +1,80 @@
+class_name InteractableExit
+extends Area2D
+
+enum EnterState {
+	NONE,
+	ENTERING,
+	CAN_TRANSITION,
+	DONE,
+}
+
+const TRANSITION_SPEED_IN = 25
+const TRANSITION_SPEED_OUT = 15
+
+export var target_pos = Vector2.ZERO
+export var move_to_scene = false
+export var scene_path : String
+
+var target = null # This is Mario
+var anim_timer = 0 # This goes up by one every frame of the animation
+var enter_state = EnterState.NONE # This indicates what phase of animation we're in
+var can_warp = false # This becomes true when Mario touches this (reset to false on enter)
+var store_state = 0 # This is Mario's current state, updated after begin-warp check
+
+func _physics_process(_delta):
+	if can_warp and target.locked == false:
+		# Begin entering door if up is pressed (while grounded + standing still)
+		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
+			# Lock Mario's input so he can't be controlled
+			target.locked = true
+			
+			# Change to "animating" state
+			can_warp = false
+			enter_state = EnterState.ENTERING
+		
+		store_state = target.state # for next frame
+	
+	if enter_state != EnterState.NONE:
+		# Run animation
+		enter_state = _update_animation(anim_timer, target)
+		# Tick the animation timer
+		anim_timer += 1
+		
+	# Begin scene-change transition if the animation is ready for it
+	if (enter_state == EnterState.CAN_TRANSITION or enter_state == EnterState.DONE) \
+		and move_to_scene == true:
+		_scene_transition(target_pos, scene_path)
+		
+	# If not changing scenes, warp Mario on anim_timer ring
+	if enter_state == EnterState.DONE and move_to_scene != true:
+		# teleport Mario within the level
+		target.position = target_pos
+		
+		# reset Mario to normal
+		target.locked = false
+		
+		# Reset door to normal
+		anim_timer = 0
+		enter_state = EnterState.NONE
+
+
+func _on_mario_touch(body):
+	if body.state == body.S.NEUTRAL:
+		can_warp = true
+		target = body
+
+
+func _on_mario_off(_body):
+	if enter_state == EnterState.NONE: # w/o this check, target will get nulled when animation ends
+		can_warp = false # Or else he won't
+		target = null
+
+
+func _update_animation(_frame: int, _mario):
+	return EnterState.DONE
+
+
+func _scene_transition(target_pos, scene_path):
+	# Default warp transition is a star iris.
+	var sweep_effect = $"/root/Singleton/WindowWarp"
+	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)

--- a/classes/interactable/interactable_exit.gd
+++ b/classes/interactable/interactable_exit.gd
@@ -1,12 +1,21 @@
 class_name InteractableExit
-extends Area2D
-
-enum EnterState {
-	NONE,
-	ENTERING,
-	CAN_TRANSITION,
-	DONE,
-}
+extends Interactable
+# A variant of Interactable that warps Mario somewhere,
+# either to another scene or someplace in the current one.
+# 
+# To implement this base class, there are two functions to extend:
+# - _animation_length() returns the expected duration of the animation
+#   as an int.
+# - _update_animation(_frame, _mario) updates the enter animation for the
+#   given frame.
+# For further customization, you can override _interact_check() if you want
+# it to respond to a different button than "up",
+# or override _begin_warp(target_pos, scene_pos) to change what transition
+# will be used on scene change (star iris out by default).
+# 
+# Please note that if the particular warp is set to move to a different scene,
+# the exit transition will begin TRANSITION_SPEED_IN frames before the end of
+# the animation.
 
 const TRANSITION_SPEED_IN = 25
 const TRANSITION_SPEED_OUT = 15
@@ -15,66 +24,71 @@ export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
 
-var target = null # This is Mario
-var anim_timer = 0 # This goes up by one every frame of the animation
-var enter_state = EnterState.NONE # This indicates what phase of animation we're in
-var can_warp = false # This becomes true when Mario touches this (reset to false on enter)
-var store_state = 0 # This is Mario's current state, updated after begin-warp check
+var mario = null # This holds a reference to Mario during the animation
+var anim_timer = -1 # This goes down by one every frame of the animation
 
-func _physics_process(_delta):
-	if can_warp and target.locked == false:
-		# Begin entering door if up is pressed (while grounded + standing still)
-		if Input.is_action_pressed("up") and store_state == target.S.NEUTRAL and target.is_on_floor():
-			# Lock Mario's input so he can't be controlled
-			target.locked = true
-			
-			# Change to "animating" state
-			can_warp = false
-			enter_state = EnterState.ENTERING
-		
-		store_state = target.state # for next frame
+
+# When interacted, go into play-animation state
+func _interact_with(body):
+	mario = body
 	
-	if enter_state != EnterState.NONE:
-		# Run animation
-		enter_state = _update_animation(anim_timer, target)
-		# Tick the animation timer
-		anim_timer += 1
-		
-	# Begin scene-change transition if the animation is ready for it
-	if (enter_state == EnterState.CAN_TRANSITION or enter_state == EnterState.DONE) \
-		and move_to_scene == true:
-		_scene_transition(target_pos, scene_path)
-		
-	# If not changing scenes, warp Mario on anim_timer ring
-	if enter_state == EnterState.DONE and move_to_scene != true:
-		# teleport Mario within the level
-		target.position = target_pos
-		
-		# reset Mario to normal
-		target.locked = false
-		
-		# Reset door to normal
-		anim_timer = 0
-		enter_state = EnterState.NONE
+	# Lock Mario's input so he can't be controlled
+	mario.locked = true
+	
+	# Change to "animating" state
+	anim_timer = _animation_length()
 
 
-func _on_mario_touch(body):
-	if body.state == body.S.NEUTRAL:
-		can_warp = true
-		target = body
+func _physics_override():
+	._physics_override()
+	
+	# Run frame-by-frame animation logic.
+	if anim_timer > -1:
+		# Step the animation one frame forward.
+		# Pass it an inverted timer so people inheriting this class can work
+		# with frames-elapsed instead of frames-left.
+		_update_animation(_animation_length() - anim_timer, mario)
+		
+		# Begin scene-change transition if the animation is ready
+		if anim_timer == min(TRANSITION_SPEED_IN, _animation_length()) and move_to_scene == true:
+			_begin_warp(target_pos, scene_path)
+			
+		# If not changing scenes, warp Mario when the timer rings
+		if anim_timer == 0 and move_to_scene != true:
+			mario.position = target_pos
+			mario.locked = false
+			
+			# No longer need this reference, let's drop it.
+			mario = null
+		
+		# Tick the animation timer.
+		# This is also what stops the timer when it runs out--
+		# when the timer is 0 and Mario warps, the timer will
+		# tick down to -1 (the "not running" value) and stop.
+		anim_timer -= 1
 
 
-func _on_mario_off(_body):
-	if enter_state == EnterState.NONE: # w/o this check, target will get nulled when animation ends
-		can_warp = false # Or else he won't
-		target = null
+# Checks if Mario is in a state where he can interact
+func _state_check(body) -> bool:
+	return !body.locked and ._state_check(body) and body.is_on_floor()
+
+
+# Checks if the trigger button was pressed
+func _interact_check() -> bool:
+	# Use Up by default, not the read-sign button (can be changed later)
+	return Input.is_action_just_pressed("up")
+
+
+func _animation_length() -> int:
+	return 0
 
 
 func _update_animation(_frame: int, _mario):
-	return EnterState.DONE
+	pass
 
 
-func _scene_transition(target_pos, scene_path):
-	# Default warp transition is a star iris.
+# Begins the exit transition. Called TRANSITION_SPEED_IN frames BEFORE the animation ends!
+func _begin_warp(target_pos, scene_path):
+	# Default warp transition is a star iris
 	var sweep_effect = $"/root/Singleton/WindowWarp"
 	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -16,6 +16,10 @@ extends Interactable
 # Please note that if the particular warp is set to move to a different scene,
 # the exit transition will begin TRANSITION_SPEED_IN frames before the end of
 # the animation.
+#
+# For convenience, an animation function is included to shift mario slowly
+# to a position. This is meant to be run once per frame, probably in the
+# entry animation, and should be useful for centering Mario to the right spot.
 
 const TRANSITION_SPEED_IN = 25
 const TRANSITION_SPEED_OUT = 15
@@ -92,3 +96,7 @@ func _begin_scene_change(target_pos, scene_path):
 	# Default warp transition is a star iris
 	var sweep_effect = $"/root/Singleton/WindowWarp"
 	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+
+
+func _mario_shift_to_position(mario, position, shift_rate):
+	mario.global_position.x = lerp(mario.global_position.x, position, shift_rate)

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -1,6 +1,6 @@
 class_name InteractableWarp
 extends Interactable
-# A variant of Interactable that warps Mario somewhere,
+# A variant of Interactable that warps the player somewhere,
 # either to another scene or someplace in the current one.
 # 
 # To implement this base class, there are two functions to extend:
@@ -29,7 +29,7 @@ export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
 
-var player = null # This holds a reference to Mario during the animation
+var player = null # This holds a reference to player object during the animation
 var anim_timer = -1 # This goes down by one every frame of the animation
 
 
@@ -37,9 +37,9 @@ var anim_timer = -1 # This goes down by one every frame of the animation
 func _interact_with(body):
 	player = body
 	
-	# Zero Mario's velocity so he doesn't keep kicking up dust
+	# Zero player's velocity so they doesn't keep kicking up dust
 	player.vel = Vector2.ZERO
-	# Lock Mario's input so he can't be controlled
+	# Lock player's input so they can't be controlled
 	player.locked = true
 	# I have no idea what sign frames are, but InteractableDialog sets them too
 	player.sign_frames = 1
@@ -62,7 +62,7 @@ func _physics_override():
 		if anim_timer == min(TRANSITION_SPEED_IN, _animation_length()) and move_to_scene == true:
 			_begin_scene_change(target_pos, scene_path)
 			
-		# If not changing scenes, warp Mario when the timer rings
+		# If not changing scenes, warp player when the timer rings
 		if anim_timer == 0 and move_to_scene != true:
 			player.position = target_pos
 			player.locked = false
@@ -72,12 +72,12 @@ func _physics_override():
 		
 		# Tick the animation timer.
 		# This is also what stops the timer when it runs out--
-		# when the timer is 0 and Mario warps, the timer will
+		# when the timer is 0 and the warp happens, the timer will
 		# tick down to -1 (the "not running" value) and stop.
 		anim_timer -= 1
 
 
-# Checks if Mario is in a state where he can interact
+# Checks if player is in a state where they can interact
 func _state_check(body) -> bool:
 	return !body.locked and ._state_check(body) and body.is_on_floor()
 

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -52,8 +52,6 @@ func _interact_with(body):
 	player.vel = Vector2.ZERO
 	# Lock player's input so they can't be controlled
 	player.locked = true
-	# I have no idea what sign frames are, but InteractableDialog sets them too
-	player.sign_frames = 1
 	
 	# Change to "animating" state
 	anim_timer = _animation_length()

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -10,8 +10,8 @@ extends Interactable
 #   given frame.
 # For further customization, you can override _interact_check() if you want
 # it to respond to a different button than "up",
-# or override _begin_warp(target_pos, scene_pos) to change what transition
-# will be used on scene change (star iris out by default).
+# or override _begin_scene_change(target_pos, scene_pos) to change what
+# transition will be used on scene change (star iris out by default).
 # 
 # Please note that if the particular warp is set to move to a different scene,
 # the exit transition will begin TRANSITION_SPEED_IN frames before the end of
@@ -51,7 +51,7 @@ func _physics_override():
 		
 		# Begin scene-change transition if the animation is ready
 		if anim_timer == min(TRANSITION_SPEED_IN, _animation_length()) and move_to_scene == true:
-			_begin_warp(target_pos, scene_path)
+			_begin_scene_change(target_pos, scene_path)
 			
 		# If not changing scenes, warp Mario when the timer rings
 		if anim_timer == 0 and move_to_scene != true:
@@ -88,7 +88,7 @@ func _update_animation(_frame: int, _mario):
 
 
 # Begins the exit transition. Called TRANSITION_SPEED_IN frames BEFORE the animation ends!
-func _begin_warp(target_pos, scene_path):
+func _begin_scene_change(target_pos, scene_path):
 	# Default warp transition is a star iris
 	var sweep_effect = $"/root/Singleton/WindowWarp"
 	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -12,6 +12,9 @@ extends Interactable
 # it to respond to a different button than "up",
 # or override _begin_scene_change(target_pos, scene_pos) to change what
 # transition will be used on scene change (star iris out by default).
+# Additionally, override _exit_pos_offset() to shift all destination positions
+# across the game by some amount. The value returned will be added to the 
+# destination.
 # 
 # Please note that if the particular warp is set to move to a different scene,
 # the exit transition will begin TRANSITION_SPEED_IN frames before the end of
@@ -69,11 +72,11 @@ func _physics_override():
 		
 		# Begin scene-change transition if the animation is ready
 		if anim_timer == min(TRANSITION_SPEED_IN, _animation_length()) and move_to_scene == true:
-			_begin_scene_change(target_pos, scene_path)
+			_begin_scene_change(target_pos + _exit_pos_offset(), scene_path)
 			
 		# If not changing scenes, warp player when the timer rings
 		if anim_timer == 0 and move_to_scene != true:
-			player.position = target_pos
+			player.position = target_pos + _exit_pos_offset()
 			player.locked = false
 			
 			# No longer need this reference, let's drop it.
@@ -84,6 +87,11 @@ func _physics_override():
 		# when the timer is 0 and the warp happens, the timer will
 		# tick down to -1 (the "not running" value) and stop.
 		anim_timer -= 1
+
+
+# Will be added to destination position.
+func _exit_pos_offset() -> Vector2:
+	return Vector2(0,0)
 
 
 # Checks if player is in a state where they can interact

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -97,10 +97,10 @@ func _update_animation(_frame: int, _player):
 
 
 # Begins the exit transition. Called TRANSITION_SPEED_IN frames BEFORE the animation ends!
-func _begin_scene_change(target_pos, scene_path):
+func _begin_scene_change(dst_pos: Vector2, dst_scene: String):
 	# Default warp transition is a star iris
 	var sweep_effect = $"/root/Singleton/WindowWarp"
-	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
+	sweep_effect.warp(dst_pos, dst_scene, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
 
 
 #func _player_shift_to_position(player, position, shift_rate):

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -103,5 +103,5 @@ func _begin_scene_change(target_pos, scene_path):
 	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
 
 
-func _player_shift_to_position(player, position, shift_rate):
-	player.global_position.x = lerp(player.global_position.x, position, shift_rate)
+#func _player_shift_to_position(player, position, shift_rate):
+#	player.global_position.x = lerp(player.global_position.x, position, shift_rate)

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -1,4 +1,4 @@
-class_name InteractableExit
+class_name InteractableWarp
 extends Interactable
 # A variant of Interactable that warps Mario somewhere,
 # either to another scene or someplace in the current one.

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -32,6 +32,17 @@ export var scene_path : String
 var player = null # This holds a reference to player object during the animation
 var anim_timer = -1 # This goes down by one every frame of the animation
 
+func _ready():
+	# Always run before player code.
+	# Normally, putting a door after the player in the hierarchy makes the door
+	# run its code after the player...which means pressing up makes the player
+	# jump (and become unable to use warps) BEFORE the warp has a chance to
+	# make the player enter, and by the time it tries the player is no longer
+	# grounded. In other words, warps only work if they're placed ABOVE the
+	# player in the scene tree.
+	# This line of code fixes that.
+	process_priority = -1
+
 
 # When interacted, go into play-animation state
 func _interact_with(body):

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -36,8 +36,12 @@ var anim_timer = -1 # This goes down by one every frame of the animation
 func _interact_with(body):
 	mario = body
 	
+	# Zero Mario's velocity so he doesn't keep kicking up dust
+	mario.vel = Vector2.ZERO
 	# Lock Mario's input so he can't be controlled
 	mario.locked = true
+	# I have no idea what sign frames are, but InteractableDialog sets them too
+	mario.sign_frames = 1
 	
 	# Change to "animating" state
 	anim_timer = _animation_length()

--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -6,7 +6,7 @@ extends Interactable
 # To implement this base class, there are two functions to extend:
 # - _animation_length() returns the expected duration of the animation
 #   as an int.
-# - _update_animation(_frame, _mario) updates the enter animation for the
+# - _update_animation(_frame, _player) updates the enter animation for the
 #   given frame.
 # For further customization, you can override _interact_check() if you want
 # it to respond to a different button than "up",
@@ -17,9 +17,10 @@ extends Interactable
 # the exit transition will begin TRANSITION_SPEED_IN frames before the end of
 # the animation.
 #
-# For convenience, an animation function is included to shift mario slowly
+# For convenience, an animation function is included to shift the player slowly
 # to a position. This is meant to be run once per frame, probably in the
-# entry animation, and should be useful for centering Mario to the right spot.
+# entry animation, and should be useful for centering the player to the right
+# spot.
 
 const TRANSITION_SPEED_IN = 25
 const TRANSITION_SPEED_OUT = 15
@@ -28,20 +29,20 @@ export var target_pos = Vector2.ZERO
 export var move_to_scene = false
 export var scene_path : String
 
-var mario = null # This holds a reference to Mario during the animation
+var player = null # This holds a reference to Mario during the animation
 var anim_timer = -1 # This goes down by one every frame of the animation
 
 
 # When interacted, go into play-animation state
 func _interact_with(body):
-	mario = body
+	player = body
 	
 	# Zero Mario's velocity so he doesn't keep kicking up dust
-	mario.vel = Vector2.ZERO
+	player.vel = Vector2.ZERO
 	# Lock Mario's input so he can't be controlled
-	mario.locked = true
+	player.locked = true
 	# I have no idea what sign frames are, but InteractableDialog sets them too
-	mario.sign_frames = 1
+	player.sign_frames = 1
 	
 	# Change to "animating" state
 	anim_timer = _animation_length()
@@ -55,7 +56,7 @@ func _physics_override():
 		# Step the animation one frame forward.
 		# Pass it an inverted timer so people inheriting this class can work
 		# with frames-elapsed instead of frames-left.
-		_update_animation(_animation_length() - anim_timer, mario)
+		_update_animation(_animation_length() - anim_timer, player)
 		
 		# Begin scene-change transition if the animation is ready
 		if anim_timer == min(TRANSITION_SPEED_IN, _animation_length()) and move_to_scene == true:
@@ -63,11 +64,11 @@ func _physics_override():
 			
 		# If not changing scenes, warp Mario when the timer rings
 		if anim_timer == 0 and move_to_scene != true:
-			mario.position = target_pos
-			mario.locked = false
+			player.position = target_pos
+			player.locked = false
 			
 			# No longer need this reference, let's drop it.
-			mario = null
+			player = null
 		
 		# Tick the animation timer.
 		# This is also what stops the timer when it runs out--
@@ -91,7 +92,7 @@ func _animation_length() -> int:
 	return 0
 
 
-func _update_animation(_frame: int, _mario):
+func _update_animation(_frame: int, _player):
 	pass
 
 
@@ -102,5 +103,5 @@ func _begin_scene_change(target_pos, scene_path):
 	sweep_effect.warp(target_pos, scene_path, TRANSITION_SPEED_IN, TRANSITION_SPEED_OUT)
 
 
-func _mario_shift_to_position(mario, position, shift_rate):
-	mario.global_position.x = lerp(mario.global_position.x, position, shift_rate)
+func _player_shift_to_position(player, position, shift_rate):
+	player.global_position.x = lerp(player.global_position.x, position, shift_rate)

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -34,7 +34,7 @@ func _physics_process(_delta):
 			if target.position.y < global_position.y:
 				target.position.y += SLIDE_SPEED
 	
-	if can_warp:
+	if can_warp and target.locked == false:
 		# Begin entering pipe if down is pressed 
 		if Input.is_action_pressed("down") and store_state == target.S.NEUTRAL and target.is_on_floor():
 			target.get_node("Voice").volume_db = -INF # Dumb solution to mario making dive sounds

--- a/project.godot
+++ b/project.godot
@@ -59,7 +59,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://classes/dejitter_group/dejitter_group.gd"
 }, {
-"base": "Area2D",
+"base": "InteractableExit",
 "class": "Door",
 "language": "GDScript",
 "path": "res://classes/interactable/door/door.gd"
@@ -118,6 +118,11 @@ _global_script_classes=[ {
 "class": "InteractableDialog",
 "language": "GDScript",
 "path": "res://classes/interactable/interactable_dialog.gd"
+}, {
+"base": "Area2D",
+"class": "InteractableExit",
+"language": "GDScript",
+"path": "res://classes/interactable/interactable_exit.gd"
 }, {
 "base": "EntityEnemyWalk",
 "class": "Koopa",
@@ -222,6 +227,7 @@ _global_script_class_icons={
 "Goomba": "",
 "Interactable": "",
 "InteractableDialog": "",
+"InteractableExit": "",
 "Koopa": "",
 "KoopaShell": "",
 "LogFall": "",

--- a/project.godot
+++ b/project.godot
@@ -59,7 +59,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://classes/dejitter_group/dejitter_group.gd"
 }, {
-"base": "Interactable",
+"base": "Area2D",
 "class": "Door",
 "language": "GDScript",
 "path": "res://classes/interactable/door/door.gd"
@@ -648,6 +648,10 @@ pointing/emulate_touch_from_mouse=true
 
 translations=PoolStringArray( "res://locale/translations/es.po", "res://locale/translations/fr.po", "res://locale/translations/it_IT.po", "res://locale/translations/nl.po" )
 locale_filter=[ 0, [  ] ]
+
+[mono]
+
+project/assembly_name="Super Mario 63 Redux"
 
 [rendering]
 

--- a/project.godot
+++ b/project.godot
@@ -64,6 +64,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://classes/interactable/door/door.gd"
 }, {
+"base": "SpriteFrames",
+"class": "DoorSkin",
+"language": "GDScript",
+"path": "res://classes/interactable/door/door_skin.gd"
+}, {
 "base": "Container",
 "class": "DropdownMenu",
 "language": "GDScript",
@@ -216,6 +221,7 @@ _global_script_class_icons={
 "CoinPickupYellow": "",
 "DejitterGroup": "res://classes/dejitter_group/dejitter_group.svg",
 "Door": "",
+"DoorSkin": "",
 "DropdownMenu": "",
 "Entity": "",
 "EntityEnemy": "",

--- a/project.godot
+++ b/project.godot
@@ -59,7 +59,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://classes/dejitter_group/dejitter_group.gd"
 }, {
-"base": "InteractableExit",
+"base": "InteractableWarp",
 "class": "Door",
 "language": "GDScript",
 "path": "res://classes/interactable/door/door.gd"
@@ -119,10 +119,10 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://classes/interactable/interactable_dialog.gd"
 }, {
-"base": "Area2D",
-"class": "InteractableExit",
+"base": "Interactable",
+"class": "InteractableWarp",
 "language": "GDScript",
-"path": "res://classes/interactable/interactable_exit.gd"
+"path": "res://classes/interactable/interactable_warp.gd"
 }, {
 "base": "EntityEnemyWalk",
 "class": "Koopa",
@@ -227,7 +227,7 @@ _global_script_class_icons={
 "Goomba": "",
 "Interactable": "",
 "InteractableDialog": "",
-"InteractableExit": "",
+"InteractableWarp": "",
 "Koopa": "",
 "KoopaShell": "",
 "LogFall": "",


### PR DESCRIPTION
Did some work to nicen up doors and make them consistent with the rest of the project:

- For starters, doors now do scene changes with WindowWarp like pipes do, rather than directly calling `get_tree().change_scene_to(next_scene)`. 
- Moved doors' origins to bottom center to facilitate snapping to the ground.
- Doors now render at Z = -1, behind Mario by default, like signs do.
- Improved the enter-door animation somewhat. The doorframe now stays in place as it should, and Mario now moves over and looks in as the door opens. This is definitely a work-in-progress, waiting on an enter-door animation for Mario, but it's a decent placeholder for now.
- Added ability to switch doors' sprites at runtime.
- Made a dedicated class for double doors. Double doors are internally two normal doors tied together, with a utility script to let you treat them as one door.

- [x] Because of WindowWarp, doors use scene paths instead of `PackedScene` now (also more consistent with pipes and warp zones).
- [x] Moving the origin probably breaks levels that use doors. It doesn't look like there are any such levels, but I just wanted to double check.
- [x] Thoughts on this method of reskinning doors? Is this a good way to do it?