### PR TITLE
Properly hide polygon-edit button in level designer

### DIFF
--- a/scenes/menus/level_designer/selection_handler.gd
+++ b/scenes/menus/level_designer/selection_handler.gd
@@ -78,7 +78,7 @@ func on_release():
 			4
 		)
 	# Show the polygon edit button
-	polygon_edit_button = true if len(selection_hit) == 1 and is_a_polygon_item(selection_hit[0]) else false
+	polygon_edit_button.visible = true if len(selection_hit) == 1 and is_a_polygon_item(selection_hit[0]) else false
 	
 	emit_signal("selection_changed", selection_rect, selection_hit)
 


### PR DESCRIPTION
Currently, the "edit polygon" button incorrectly shows for all objects in the level designer, not just polygon objects:
![image](https://user-images.githubusercontent.com/29995463/201299448-7e9d6204-a9fa-4e02-bbd7-82dd9f7ccd61.png)

Looks like code to fix this was almost finished; this just pushes it the last little bit of the way there.
![image](https://user-images.githubusercontent.com/29995463/201299735-c03ac8ab-7894-4caa-97b9-ab6f67bf6d01.png)
