### PR TITLE
Ignore auto-generated .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ export_presets.cfg
 data_*/
 main.tscn
 
+# IDE-specific ignores
+.vscode/*
+
 # Pipescript Target Ignores
 pipescript/target
 pipescript/compile_tool.sh


### PR DESCRIPTION
On occasion, I like to use Visual Studio Code (VSCode) to write and edit GDScript. When VSCode loads a project root folder, it auto-generates a `.vscode` folder in the root folder. Its contents absolutely should not be versioned because they are highly user-specific, and basically irrelevant to the project at large.