### PR TITLE
Refactor pipes again

### DIFF
--- a/classes/interactable/interactable_warp.gd
+++ b/classes/interactable/interactable_warp.gd
@@ -109,7 +109,15 @@ func _animation_length() -> int:
 	return 0
 
 
+func _begin_animation(_player):
+	pass
+
+
 func _update_animation(_frame: int, _player):
+	pass
+
+
+func _end_animation(_player):
 	pass
 
 

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -2,8 +2,6 @@ extends InteractableWarp
 
 const PIPE_HEIGHT = 30
 const SLIDE_SPEED = 0.7
-const CENTERING_SPEED_SLOW = 0.25
-const CENTERING_SPEED_FAST = 0.75
 
 var store_state = 0
 var ride_area
@@ -20,10 +18,8 @@ func _animation_length() -> int:
 	return 60
 
 func _begin_animation(_player):
-	# Center player slightly - REPLACE WITH read_pos_x
-	_player.position = Vector2(
-		lerp(_player.position.x, global_position.x, CENTERING_SPEED_SLOW),
-		global_position.y - PIPE_HEIGHT)
+	# Set player to center gradually
+	_player.read_pos_x = global_position.x
 	
 	# Give player slide-down animation
 	_player.get_node("Character").set_animation("front")
@@ -37,9 +33,7 @@ func _update_animation(_frame, _player):
 	# Slide player a little further into the pipe.
 	if _player.state == 7: # Not a valid value
 		_player.position.y = global_position.y
-		_player.position.x = lerp(_player.position.x, global_position.x, CENTERING_SPEED_FAST)
 	else:
-		_player.position.x = lerp(_player.position.x, global_position.x, CENTERING_SPEED_SLOW)
 		if _player.position.y < global_position.y:
 			_player.position.y += SLIDE_SPEED
 

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -31,11 +31,8 @@ func _begin_animation(_player):
 		
 func _update_animation(_frame, _player):
 	# Slide player a little further into the pipe.
-	if _player.state == 7: # Not a valid value
-		_player.position.y = global_position.y
-	else:
-		if _player.position.y < global_position.y:
-			_player.position.y += SLIDE_SPEED
+	# TODO: Go fast if entering via pound.
+	_player.position.y = min(global_position.y, _player.position.y + SLIDE_SPEED)
 
 
 func _end_animation(_player):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -23,9 +23,9 @@ func _begin_animation(_player):
 	_player.read_pos_x = global_position.x
 	
 	# Give player slide-down animation
-	_player.get_node("Character").set_animation("front")
-	_player.get_node("Character").rotation = 0 # Keeps player from turning sideways
-	_player.get_node("Voice").volume_db = -INF # Keeps player from making dive sounds
+	_player.switch_anim("front")
+	_player.sprite.rotation = 0 # Keeps player from turning sideways
+	_player.voice.volume_db = -INF # Keeps player from making dive sounds
 	
 	# Play pipe-enter sound
 	sound.play()
@@ -41,7 +41,7 @@ func _update_animation(_frame, _player):
 
 func _end_animation(_player):
 	# Reset player's voice clips to normal volume.
-	_player.get_node("Voice").volume_db = -5
+	_player.voice.volume_db = -5
 	
 	_player.switch_state(_player.S.NEUTRAL)
 	_player.switch_anim("walk")

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -1,6 +1,6 @@
 extends InteractableWarp
 
-const PIPE_HEIGHT = 30
+const PLAYER_STOP_HEIGHT = 15
 const SLIDE_SPEED = 0.7
 
 var store_state = 0
@@ -32,7 +32,9 @@ func _begin_animation(_player):
 func _update_animation(_frame, _player):
 	# Slide player a little further into the pipe.
 	# TODO: Go fast if entering via pound.
-	_player.position.y = min(global_position.y, _player.position.y + SLIDE_SPEED)
+	_player.position.y = min(
+		global_position.y - PLAYER_STOP_HEIGHT,
+		_player.position.y + SLIDE_SPEED)
 
 
 func _end_animation(_player):

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -17,6 +17,7 @@ func _interact_check() -> bool:
 func _animation_length() -> int:
 	return 60
 
+
 func _begin_animation(_player):
 	# Set player to center gradually
 	_player.read_pos_x = global_position.x
@@ -28,7 +29,8 @@ func _begin_animation(_player):
 	
 	# Play pipe-enter sound
 	sound.play()
-		
+
+
 func _update_animation(_frame, _player):
 	# Slide player a little further into the pipe.
 	# TODO: Go fast if entering via pound.
@@ -47,6 +49,7 @@ func _end_animation(_player):
 
 	# Force end pipe sound, just in case.
 	sound.stop()
+
 
 func set_disabled(val):
 	disabled = val

--- a/classes/interactable/pipe/pipe.gd
+++ b/classes/interactable/pipe/pipe.gd
@@ -6,10 +6,9 @@ const CENTERING_SPEED_SLOW = 0.25
 const CENTERING_SPEED_FAST = 0.75
 
 var store_state = 0
+var ride_area
 
-onready var sweep_effect = $"/root/Singleton/WindowWarp"
 onready var sound = $SFX # for sound effect
-onready var ride_area = $Area2D
 
 func _interact_check() -> bool:
 	# Interact when Down is pressed.
@@ -60,5 +59,5 @@ func set_disabled(val):
 	disabled = val
 	set_collision_layer_bit(0, 0 if val else 1)
 	if ride_area == null:
-		ride_area = $Area2D
+		ride_area = self
 	ride_area.monitoring = !val

--- a/classes/interactable/pipe/pipe.tscn
+++ b/classes/interactable/pipe/pipe.tscn
@@ -10,33 +10,27 @@ extents = Vector2( 4.36713, 15 )
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 15.9792, 16.0339 )
 
-[node name="Pipe" type="StaticBody2D"]
+[node name="Pipe" type="Area2D"]
 collision_mask = 0
+monitorable = false
 script = ExtResource( 3 )
+sprite = NodePath("Sprite")
+
+[node name="DetectorArea" type="CollisionShape2D" parent="."]
+position = Vector2( 0, -25 )
+shape = SubResource( 1 )
+__meta__ = {
+"_editor_description_": "When the player is in this area, they can go down the pipe."
+}
 
 [node name="Sprite" type="Sprite" parent="."]
 position = Vector2( 0, -16 )
 z_index = 1
 texture = ExtResource( 2 )
 
-[node name="Area2D" type="Area2D" parent="."]
-position = Vector2( 0, -16 )
-collision_layer = 0
-collision_mask = 2
-input_pickable = false
-monitorable = false
-__meta__ = {
-"_editor_description_": "Detects if Mario is on pipe"
-}
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-position = Vector2( 0, -9 )
-shape = SubResource( 1 )
-__meta__ = {
-"_editor_description_": ""
-}
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2( 0, -16 )
 z_index = 1
 shape = SubResource( 2 )
@@ -46,6 +40,3 @@ __meta__ = {
 
 [node name="SFX" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 1 )
-
-[connection signal="body_entered" from="Area2D" to="." method="_on_mario_top"]
-[connection signal="body_exited" from="Area2D" to="." method="_on_mario_off"]

--- a/classes/interactable/pipe/pipe.tscn
+++ b/classes/interactable/pipe/pipe.tscn
@@ -15,10 +15,12 @@ collision_mask = 0
 script = ExtResource( 3 )
 
 [node name="Sprite" type="Sprite" parent="."]
+position = Vector2( 0, -16 )
 z_index = 1
 texture = ExtResource( 2 )
 
 [node name="Area2D" type="Area2D" parent="."]
+position = Vector2( 0, -16 )
 collision_layer = 0
 collision_mask = 2
 input_pickable = false
@@ -35,6 +37,7 @@ __meta__ = {
 }
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2( 0, -16 )
 z_index = 1
 shape = SubResource( 2 )
 __meta__ = {


### PR DESCRIPTION
**Plans for PR:**
- [x] Now that the door refactor has landed, it's now possible to make pipes extend `InteractableWarp`. This makes the code much smaller and more intelligible, though it does also require rebuilding the prefab to put the Area2D as the root and the StaticBody2D as a child.
- [x] Like doors, move the pipe origin to the bottom to facilitate snapping to ground.
- [ ] Quick pipe--ground pound to enter pipes fast.
- [ ] Full visual support for lightly rotated pipes, as demonstrated by Wobuffet Forme Pikachu on the Discord. Current code always orients and slides the player as if all pipes are exactly vertical.
- [ ] Maybe support for pipes at _any_ angle, including sideways and upwards? I can think of exactly one place in the main campaign that this might _possibly_ be useful (SL igloo entrance), but it'd be lots of fun in user-created levels.

**Questions on current status:**

- Knowing the level designer is meant to be the tool of choice for the main campaign, is the origin change needed? Would it be better to revert that part?
- What the hey is going on in the disable code? It's not used right now, but I don't want to remove it until I know if the collision mask, `ride_area`, etc. are important.
- Similarly, is it necessary to manually switch player state/animation to neutral on warp end? Seems like it works fine to let the player object self-regulate.

**Notes on future plans:**
I would like to implement quick-pipe, but in the current codebase there's no elegant way to trigger an Interactable based solely on player state.

My plan was to override Pipe's `_interact_check()` function so it checks if down is pressed _or player is pounding_, but unfortunately there's no way to get player state in `_interact_check()` at the moment--`InteractableWarp` does store a reference to the player, but it's not assigned until _after_ `_interact_check()` runs in the base `Interactable` method. I really, really do not want to modify `Interactable` to make this one case work--not only is that outside the scope of a pipe PR, but it seems stupid to make `_interact_check()` functionally the same as `_state_check(body)` when they're clearly intended to do different things!

I can think of a hacky way to do it: have `_interact_check()` always return `true` and move input checking into `_state_check(body)` instead. It's a terrible solution--relies on these two functions being used solely as two sides of an `and` operation in `Interactable`, which means it could break if `Interactable`'s implementation changes.
**Would it be best to just do it the hacky way** (preferably with clear explanations as to what's going on and why it's a bad solution)**?**