### PR TITLE
Canonize branch naming conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,23 @@ Ensure that you provide as much detail as possible on *how* the bug happened. Th
 ## Contributing code
 ### Preparation
 If you would like to make a contribution, begin by posting a feature request in the "Issues" section. This will allow us to review your plans, suggest alterations, or potentially reject the idea if necessary. From there, you can fork the project, make your alterations, and issue a pull request.
+### Branching
+Name your branches using the following conventions (fill the blanks as appropriate):
+- `feature-___` if the branch adds large-scale features, such as entire enemies, items, or systems.
+Example: `feature-shy-guys`
+- `enhance-___` when an existing feature is being tweaked or added to.
+Example: `enhance-fludd-spray`
+- `refactor-___` for changes that make the code nicer to work with.
+(Since nodes interact so tightly with the code, they are counted as part of this category.)
+Example: `refactor-enemy-base-class`
+- `bugfix-___` when _only_ fixing something that doesn't work right. Branches in other categories can also fix bugs, of course.
+Example: `bugfix-fish-not-hurting-player`
+- `asset-___` when _only_ integrating art/sound assets into the project. Features and enhancements may also introduce assets.
+Example: `asset-bobomb-sfx`
+- `repo-___` if the change affects the GitHub repository, e.g. `README.md` or `CONTRIBUTING.md`.
+Example: `repo-clarify-styleguide`
+
+Delete branches once they've been merged, to keep the tree clean.
 ### Styling
 Follow the [Godot style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html) as closely as possible, albeit with the following alterations:
 * The keywords `and` and `or` are used in place of the C-like `&&` and `||` as-per the style guide, however we use the `!` symbol as opposed to `not`, to allow easier reading of more complex boolean expressions. So, `if !foo and !bar:`


### PR DESCRIPTION
# Description of changes
Adds branch naming conventions to the style guide. These were discussed on the Discord server, and it seems wise to lock them in for our own ease of reference (as well as outsiders').

I took the liberty of adding the `repo-___` category for changes to the repository itself (like this one!), since this definitely won't be the last time anybody needs to update the style guide :)

# Reviewer(s)
@GTcreyon @jaschutte 

# Issue(s)
N/A
