### PR TITLE
Customizable lifetime for falling logs

### DIFF
--- a/classes/solid/log/log_fall.gd
+++ b/classes/solid/log/log_fall.gd
@@ -1,5 +1,7 @@
 class_name LogFall
 extends StaticBody2D
+# A log that reacts when something stands on it.
+# It jitters around, before falling, and disappearing after a set time period.
 
 const GRAVITY = 0.17
 const MAX_SPEED = 4

--- a/classes/solid/log/log_fall.gd
+++ b/classes/solid/log/log_fall.gd
@@ -2,7 +2,7 @@ class_name LogFall
 extends StaticBody2D
 
 const GRAVITY = 0.17
-
+const MAX_SPEED = 4
 const JITTER = 2
 
 onready var sprite: Sprite = $Sprite
@@ -11,10 +11,12 @@ onready var ride_area: RideArea = $RideArea
 
 export var disabled: bool = false setget set_disabled
 export var wait_time: int = 60
+export var lifetime: int = 60
 
 var vel = Vector2.ZERO
 var falling: bool = false
 var rng = RandomNumberGenerator.new()
+var time_falling: int = 0
 
 
 func _ready():
@@ -22,22 +24,39 @@ func _ready():
 
 
 func _physics_process(_delta):
-	if falling:
-		if !disabled:
+	if !disabled:
+		if falling:
 			if wait_time > 0:
 				wait_time -= 1
+				# Jitter the sprite around
 				sprite.offset = Vector2((rng.randi() % (JITTER + 1)) - JITTER / 2.0, (rng.randi() % (JITTER + 1)) - JITTER / 2.0)
 			elif wait_time <= 0:
+				# Reset the offset
 				sprite.offset = Vector2.ZERO
-				vel.y += GRAVITY
-				position += vel
 				
-			if !visibility.is_on_screen():
-				queue_free()
-	else:
-		if ride_area.has_rider():
-			falling = true
-			ride_area.queue_free()
+				# Fall until we hit the max speed
+				if vel.y <= MAX_SPEED - GRAVITY:
+					vel.y += GRAVITY
+				else:
+					vel.y = MAX_SPEED
+				position += vel
+			
+				time_falling += 1
+				
+				# If lifetime has expired
+				if time_falling > lifetime:
+					modulate.a -= 0.125
+					
+					# Disable collision
+					collision_layer = 0
+				
+				if !visibility.is_on_screen() or modulate.a < 0:
+					queue_free()
+		else:
+			# If something steps on it
+			if ride_area.has_rider():
+				falling = true
+				ride_area.queue_free()
 
 
 func set_disabled(val):


### PR DESCRIPTION
# Description of changes
Logs now have a customizable lifetime, set with an export variable. They will fall until they reach a max speed (such that Mario doesn't fall off), and fade out when the timer runs out.