### PR TITLE
Two renames of Singleton.n got missed

### DIFF
--- a/classes/pickup/fludd_box/fludd_box.gd
+++ b/classes/pickup/fludd_box/fludd_box.gd
@@ -3,7 +3,7 @@ extends Area2D
 # Box that drops a fludd nozzle when stomped.
 
 
-export(Singleton.n) var nozzle: int
+export(Singleton.Nozzles) var nozzle: int
 
 var PICKUP_PREFABS = [
 	preload("./fludd_pickup_hover.tscn"),

--- a/classes/pickup/fludd_box/fludd_pickup.gd
+++ b/classes/pickup/fludd_box/fludd_pickup.gd
@@ -2,7 +2,7 @@ class_name FluddPickup
 extends Pickup
 
 
-export(Singleton.n) var nozzle_award: int
+export(Singleton.Nozzles) var nozzle_award: int
 
 
 func _award_pickup(body):


### PR DESCRIPTION
# Description of changes
#82 missed a couple spots when it renamed the FLUDD nozzle enum. Fixing those real quick.

# Reviewer(s)
@GTcreyon 
@jaschutte 

# Issue(s)
N/A
