### PR TITLE
Align hover spray to nozzle

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -420,6 +420,8 @@ func adjust_swim_x() -> void:
 	vel.x += (swim_adjust - vel.x) * FPS_MOD
 
 
+const SPRAY_ORIGIN_STAND = Vector2(-10, -2)
+const SPRAY_ORIGIN_DIVE = Vector2(1, -9)
 var hover_sound_position = 0
 var nozzle_fx_scale = 0
 func fixed_visuals() -> void:
@@ -461,23 +463,15 @@ func fixed_visuals() -> void:
 	nozzle_fx.visible = nozzle_fx_scale > 0
 	nozzle_fx.scale = Vector2.ONE * nozzle_fx_scale
 
-	var bubblepos = position
+	var spray_pos = position
 	if state == S.DIVE:
-		bubblepos.y += -9
-		if sprite.flip_h:
-			bubblepos.x += -1
-		else:
-			bubblepos.x += 1
+		spray_pos += SPRAY_ORIGIN_DIVE * Vector2(facing_sign(), 1)
 	else:
-		bubblepos.y += -2
-		if sprite.flip_h:
-			bubblepos.x += 10
-		else:
-			bubblepos.x += -10
+		spray_pos += SPRAY_ORIGIN_STAND * Vector2(facing_sign(), 1)
 	# offset spray particles to mario's center
-	spray_particles.position = bubblepos
+	spray_particles.position = spray_pos
 	# plume is relative to parent unlike particles, so make position local
-	nozzle_fx.position = bubblepos - position
+	nozzle_fx.position = spray_pos - position
 	
 	spray_particles.rotation = sprite.rotation
 	nozzle_fx.rotation = sprite.rotation

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -420,7 +420,7 @@ func adjust_swim_x() -> void:
 	vel.x += (swim_adjust - vel.x) * FPS_MOD
 
 
-const SPRAY_ORIGIN = Vector2(-9, 4)
+const SPRAY_ORIGIN = Vector2(-9, 6)
 const PLUME_ORIGIN = Vector2(-10, -2)
 var hover_sound_position = 0
 var nozzle_fx_scale = 0

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -421,8 +421,7 @@ func adjust_swim_x() -> void:
 
 
 const SPRAY_ORIGIN = Vector2(-9, 4)
-const PLUME_ORIGIN_STAND = Vector2(-10, -2)
-const PLUME_ORIGIN_DIVE = Vector2(1, -9)
+const PLUME_ORIGIN = Vector2(-10, -2)
 var hover_sound_position = 0
 var nozzle_fx_scale = 0
 func fixed_visuals() -> void:
@@ -468,15 +467,14 @@ func fixed_visuals() -> void:
 	var plume_pos: Vector2
 	# offset spray effect relative to player's center
 	spray_pos = SPRAY_ORIGIN
-	if state == S.DIVE:
-		plume_pos = PLUME_ORIGIN_DIVE
-	else:
-		plume_pos = PLUME_ORIGIN_STAND
+	plume_pos = PLUME_ORIGIN
 	# factor in facing direction
 	spray_pos *= Vector2(facing_sign(), 1)
 	plume_pos *= Vector2(facing_sign(), 1)
-	# particles are in global space, move them to player-relative local space
+	# rotate positions with sprite, so they stay aligned
 	spray_pos = spray_pos.rotated(sprite.rotation)
+	plume_pos = plume_pos.rotated(sprite.rotation)
+	# particles are in global space, move them to player-relative position
 	spray_pos += position
 	# apply spray and plume positions
 	spray_particles.position = spray_pos

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -420,8 +420,7 @@ func adjust_swim_x() -> void:
 	vel.x += (swim_adjust - vel.x) * FPS_MOD
 
 
-const SPRAY_ORIGIN_STAND = Vector2(-9, 4)
-const SPRAY_ORIGIN_DIVE = Vector2(-9, 4)
+const SPRAY_ORIGIN = Vector2(-9, 4)
 const PLUME_ORIGIN_STAND = Vector2(-10, -2)
 const PLUME_ORIGIN_DIVE = Vector2(1, -9)
 var hover_sound_position = 0
@@ -468,11 +467,10 @@ func fixed_visuals() -> void:
 	var spray_pos: Vector2
 	var plume_pos: Vector2
 	# offset spray effect relative to player's center
+	spray_pos = SPRAY_ORIGIN
 	if state == S.DIVE:
-		spray_pos = SPRAY_ORIGIN_DIVE
 		plume_pos = PLUME_ORIGIN_DIVE
 	else:
-		spray_pos = SPRAY_ORIGIN_STAND
 		plume_pos = PLUME_ORIGIN_STAND
 	# factor in facing direction
 	spray_pos *= Vector2(facing_sign(), 1)

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -421,7 +421,9 @@ func adjust_swim_x() -> void:
 
 
 const SPRAY_ORIGIN_STAND = Vector2(-9, 4)
-const SPRAY_ORIGIN_DIVE = Vector2(1, -9)
+const SPRAY_ORIGIN_DIVE = Vector2(-9, -9) #NOTE: This is global space, not local
+const PLUME_ORIGIN_STAND = Vector2(-10, -2)
+const PLUME_ORIGIN_DIVE = Vector2(1, -9)
 var hover_sound_position = 0
 var nozzle_fx_scale = 0
 func fixed_visuals() -> void:
@@ -463,15 +465,17 @@ func fixed_visuals() -> void:
 	nozzle_fx.visible = nozzle_fx_scale > 0
 	nozzle_fx.scale = Vector2.ONE * nozzle_fx_scale
 
-	var spray_pos = position
-	if state == S.DIVE:
-		spray_pos += SPRAY_ORIGIN_DIVE * Vector2(facing_sign(), 1)
-	else:
-		spray_pos += SPRAY_ORIGIN_STAND * Vector2(facing_sign(), 1)
-	# offset spray particles to mario's center
+	# offset spray particles relative to player's center
+	var spray_pos = SPRAY_ORIGIN_DIVE if state == S.DIVE else SPRAY_ORIGIN_STAND
+	spray_pos *= Vector2(facing_sign(), 1)
+	# likewise with plume
+	var plume_pos = PLUME_ORIGIN_DIVE if state == S.DIVE else PLUME_ORIGIN_STAND
+	plume_pos *= Vector2(facing_sign(), 1)
+	# particles are in global space, move them to player-relative local space
+	spray_pos += position
+	# apply spray and plume positions
 	spray_particles.position = spray_pos
-	# plume is relative to parent unlike particles, so make position local
-	nozzle_fx.position = spray_pos - position
+	nozzle_fx.position = plume_pos
 	
 	spray_particles.rotation = sprite.rotation
 	nozzle_fx.rotation = sprite.rotation

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -465,11 +465,17 @@ func fixed_visuals() -> void:
 	nozzle_fx.visible = nozzle_fx_scale > 0
 	nozzle_fx.scale = Vector2.ONE * nozzle_fx_scale
 
-	# offset spray particles relative to player's center
-	var spray_pos = SPRAY_ORIGIN_DIVE if state == S.DIVE else SPRAY_ORIGIN_STAND
+	var spray_pos: Vector2
+	var plume_pos: Vector2
+	# offset spray effect relative to player's center
+	if state == S.DIVE:
+		spray_pos = SPRAY_ORIGIN_DIVE
+		plume_pos = PLUME_ORIGIN_DIVE
+	else:
+		spray_pos = SPRAY_ORIGIN_STAND
+		plume_pos = PLUME_ORIGIN_STAND
+	# factor in facing direction
 	spray_pos *= Vector2(facing_sign(), 1)
-	# likewise with plume
-	var plume_pos = PLUME_ORIGIN_DIVE if state == S.DIVE else PLUME_ORIGIN_STAND
 	plume_pos *= Vector2(facing_sign(), 1)
 	# particles are in global space, move them to player-relative local space
 	spray_pos += position

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -420,7 +420,7 @@ func adjust_swim_x() -> void:
 	vel.x += (swim_adjust - vel.x) * FPS_MOD
 
 
-const SPRAY_ORIGIN_STAND = Vector2(-10, -2)
+const SPRAY_ORIGIN_STAND = Vector2(-9, 4)
 const SPRAY_ORIGIN_DIVE = Vector2(1, -9)
 var hover_sound_position = 0
 var nozzle_fx_scale = 0

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -421,7 +421,7 @@ func adjust_swim_x() -> void:
 
 
 const SPRAY_ORIGIN_STAND = Vector2(-9, 4)
-const SPRAY_ORIGIN_DIVE = Vector2(-9, -9) #NOTE: This is global space, not local
+const SPRAY_ORIGIN_DIVE = Vector2(-9, 4)
 const PLUME_ORIGIN_STAND = Vector2(-10, -2)
 const PLUME_ORIGIN_DIVE = Vector2(1, -9)
 var hover_sound_position = 0
@@ -478,6 +478,7 @@ func fixed_visuals() -> void:
 	spray_pos *= Vector2(facing_sign(), 1)
 	plume_pos *= Vector2(facing_sign(), 1)
 	# particles are in global space, move them to player-relative local space
+	spray_pos = spray_pos.rotated(sprite.rotation)
 	spray_pos += position
 	# apply spray and plume positions
 	spray_particles.position = spray_pos


### PR DESCRIPTION
# Description of changes
Adjusts hover spray offset to visually match the position of the nozzle.

This was done by a simple change to the particle system's hard-coded position offset, as well as some refactoring to make the offset easier to tune. The spray plume effect was also being placed using this offset, and it looked fine already, so I had to give it its own offset value to keep it where it already was.

While testing, I discovered that not only did the spray effect have a different offset when diving, but that said offset didn't even change with the player's rotation. By making the offset rotate appropriately, I was able to completely remove the dive offset and rely on the normal offset value for everything, and end up with spray consistently coming from the nozzle no matter what angle Mario is currently diving.

# Reviewer(s)
@GTcreyon @RandomCatDude @jaschutte 

# Issue(s)
Closes #81 
