### PR TITLE
Add sound infrastructure to pickup baseclass

### DIFF
--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -28,9 +28,11 @@ static func new_from_existing (
 	scene_root: Node,
 	destroy_on_finished = true
 ):
-	# Reparent to scene root.
+	# Reparent to scene root, while preserving global position.
+	var sound_pos = sfx.global_position
 	sfx.get_parent().remove_child(sfx)
 	scene_root.add_child(sfx)
+	sfx.global_position = sound_pos
 	
 	# Make the sfx player destroy on playback (if desired)
 	if destroy_on_finished:

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -19,3 +19,21 @@ func _on_ResidualSFX_finished():
 func _init(sound: AudioStream, pos: Vector2):
 	position = pos
 	stream = sound
+
+
+# Takes an existing AudioStreamPlayer2D and makes it act like a ResidualSFX
+# (outlive its parent, optionally destroy on finish).
+static func new_from_existing (
+	sfx: AudioStreamPlayer2D,
+	scene_root: Node,
+	destroy_on_finished = true
+):
+	# Reparent to scene root.
+	sfx.get_parent().remove_child(sfx)
+	scene_root.add_child(sfx)
+	
+	# Make the sfx player destroy on playback (if desired)
+	if destroy_on_finished:
+		sfx.connect("finished", sfx, "queue_free")
+	# Lesgo
+	sfx.play()

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -21,21 +21,28 @@ func _init(sound: AudioStream, pos: Vector2):
 	stream = sound
 
 
-# Takes an existing AudioStreamPlayer2D and makes it act like a ResidualSFX
+# Takes an existing AudioStreamPlayer(2D) and makes it act like a ResidualSFX
 # (outlive its parent, optionally destroy on finish).
 static func new_from_existing (
-	sfx: AudioStreamPlayer2D,
+	sfx,
 	scene_root: Node,
 	destroy_on_finished = true
 ):
-	# Reparent to scene root, while preserving global position.
-	var sound_pos = sfx.global_position
-	sfx.get_parent().remove_child(sfx)
-	scene_root.add_child(sfx)
-	sfx.global_position = sound_pos
+	if sfx is Node2D:
+		# Reparent to scene root, while preserving global position.
+		var sound_pos = sfx.global_position
+		_move_node_to(sfx, scene_root)
+		sfx.global_position = sound_pos
+	else:
+		# Reparent to the scene root.
+		_move_node_to(sfx, scene_root)
 	
 	# Make the sfx player destroy on playback (if desired)
 	if destroy_on_finished:
 		sfx.connect("finished", sfx, "queue_free")
 	# Lesgo
 	sfx.play()
+
+static func _move_node_to (node: Node, new_parent: Node):
+	node.get_parent().remove_child(node)
+	new_parent.add_child(node)

--- a/classes/pickup/bottle/bottle_big.tscn
+++ b/classes/pickup/bottle/bottle_big.tscn
@@ -13,6 +13,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 1 )
 persistent_collect = false
+_sfx_path = NodePath("")
 amount = 50
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/classes/pickup/bottle/bottle_small.tscn
+++ b/classes/pickup/bottle/bottle_small.tscn
@@ -13,6 +13,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 2 )
 persistent_collect = false
+_sfx_path = NodePath("")
 
 [node name="Sprite" type="Sprite" parent="."]
 position = Vector2( 0, -1 )

--- a/classes/pickup/coin/blue/coin_blue.tscn
+++ b/classes/pickup/coin/blue/coin_blue.tscn
@@ -49,6 +49,7 @@ monitorable = false
 script = ExtResource( 1 )
 parent_is_root = true
 _sprite_path = NodePath("../AnimatedSprite")
+_sfx_path = NodePath("")
 particle_texture = ExtResource( 6 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]

--- a/classes/pickup/coin/red/coin_red.tscn
+++ b/classes/pickup/coin/red/coin_red.tscn
@@ -49,6 +49,7 @@ monitorable = false
 script = ExtResource( 13 )
 parent_is_root = true
 _sprite_path = NodePath("../AnimatedSprite")
+_sfx_path = NodePath("")
 particle_texture = ExtResource( 6 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]

--- a/classes/pickup/coin/yellow/coin_yellow.tscn
+++ b/classes/pickup/coin/yellow/coin_yellow.tscn
@@ -50,6 +50,7 @@ monitorable = false
 script = ExtResource( 9 )
 parent_is_root = true
 _sprite_path = NodePath("../AnimatedSprite")
+_sfx_path = NodePath("")
 particle_texture = ExtResource( 11 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]

--- a/classes/pickup/fludd_box/fludd_pickup_hover.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_hover.tscn
@@ -27,6 +27,7 @@ monitorable = false
 script = ExtResource( 2 )
 parent_is_root = true
 persistent_collect = false
+_sfx_path = NodePath("")
 nozzle_award = 1
 
 [node name="Sprite" type="Sprite" parent="Hover"]

--- a/classes/pickup/fludd_box/fludd_pickup_rocket.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_rocket.tscn
@@ -27,6 +27,7 @@ monitorable = false
 script = ExtResource( 2 )
 parent_is_root = true
 persistent_collect = false
+_sfx_path = NodePath("")
 nozzle_award = 2
 
 [node name="Sprite" type="Sprite" parent="Rocket"]

--- a/classes/pickup/fludd_box/fludd_pickup_turbo.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_turbo.tscn
@@ -26,6 +26,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 2 )
 persistent_collect = false
+_sfx_path = NodePath("")
 nozzle_award = 3
 
 [node name="Sprite" type="Sprite" parent="Turbo"]

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -70,9 +70,11 @@ func _pickup_id_setup() -> void:
 
 func _pickup_sound():
 	if sfx != null:
+		# Find an object we know will survive this object's destruction.
 		var safe_sfx_root = get_parent()
 		if parent_is_root:
 			safe_sfx_root = safe_sfx_root.get_parent()
+		# Anchor the sound source to that, then play it.
 		ResidualSFX.new_from_existing(sfx, safe_sfx_root)
 
 

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -9,7 +9,7 @@ export var parent_is_root: bool = false
 export var persistent_collect = true
 export var disabled: bool = false setget set_disabled
 export var _sprite_path: NodePath = "Sprite"
-export var _sfx_path: NodePath = "SFXPickup"
+export var _sfx_path: NodePath = "SFXCollect"
 
 var _pickup_id: int = -1
 

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -9,7 +9,7 @@ export var parent_is_root: bool = false
 export var persistent_collect = true
 export var disabled: bool = false setget set_disabled
 export var _sprite_path: NodePath = "Sprite"
-export var _sfx_path: NodePath = "GrabSFX"
+export var _sfx_path: NodePath = "SFXPickup"
 
 var _pickup_id: int = -1
 

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -9,10 +9,12 @@ export var parent_is_root: bool = false
 export var persistent_collect = true
 export var disabled: bool = false setget set_disabled
 export var _sprite_path: NodePath = "Sprite"
+export var _sfx_path: NodePath = "GrabSFX"
 
 var _pickup_id: int = -1
 
 onready var sprite = get_node_or_null(_sprite_path)
+onready var sfx = get_node_or_null(_sfx_path)
 
 
 func _ready():
@@ -36,6 +38,7 @@ func assign_pickup_id(id) -> void:
 
 func pickup(body) -> void:
 	_award_pickup(body)
+	_pickup_sound()
 	_pickup_effect()
 	_kill_pickup()
 	if persistent_collect:
@@ -63,6 +66,13 @@ func _pickup_id_setup() -> void:
 			get_parent().queue_free()
 		else:
 			queue_free()
+
+
+func _pickup_sound():
+	var safe_sfx_root = get_parent()
+	if parent_is_root:
+		safe_sfx_root = safe_sfx_root.get_parent()
+	ResidualSFX.new_from_existing(sfx, safe_sfx_root)
 
 
 func _kill_pickup() -> void:

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -69,10 +69,11 @@ func _pickup_id_setup() -> void:
 
 
 func _pickup_sound():
-	var safe_sfx_root = get_parent()
-	if parent_is_root:
-		safe_sfx_root = safe_sfx_root.get_parent()
-	ResidualSFX.new_from_existing(sfx, safe_sfx_root)
+	if sfx != null:
+		var safe_sfx_root = get_parent()
+		if parent_is_root:
+			safe_sfx_root = safe_sfx_root.get_parent()
+		ResidualSFX.new_from_existing(sfx, safe_sfx_root)
 
 
 func _kill_pickup() -> void:


### PR DESCRIPTION
# Description of changes
Adds sound support directly to the pickup base class, so it can be shared between all pickups with zero effort.

The design is similar to #85, just a whole lot simpler (only one sound hook instead of three).

# Reviewer(s)
@GTcreyon @jaschutte

# Issue(s)
Important step towards #35.
