### PR TITLE
Respawn bottles on a timer

### DIFF
--- a/classes/pickup/bottle/bottle.gd
+++ b/classes/pickup/bottle/bottle.gd
@@ -13,4 +13,4 @@ func _award_pickup(_body) -> void:
 
 func set_disabled(value):
 	disabled = value
-	monitoring = !value
+	set_deferred("monitoring", !value)

--- a/classes/pickup/bottle/bottle.gd
+++ b/classes/pickup/bottle/bottle.gd
@@ -8,7 +8,6 @@ export var amount: int = 15
 func _award_pickup(_body) -> void:
 	if _body.water < 100:
 		_body.water = min(_body.water + amount, 100)
-		queue_free()
 
 
 func set_disabled(value):

--- a/classes/pickup/bottle/bottle_big.tscn
+++ b/classes/pickup/bottle/bottle_big.tscn
@@ -13,6 +13,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 1 )
 persistent_collect = false
+respawn_seconds = 30.0
 amount = 50
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/classes/pickup/bottle/bottle_small.tscn
+++ b/classes/pickup/bottle/bottle_small.tscn
@@ -13,6 +13,7 @@ input_pickable = false
 monitorable = false
 script = ExtResource( 2 )
 persistent_collect = false
+respawn_seconds = 30.0
 
 [node name="Sprite" type="Sprite" parent="."]
 position = Vector2( 0, -1 )

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -29,7 +29,7 @@ func _ready_override() -> void:
 	_connect_signals()
 
 
-func _physics_process(delta):
+func _physics_process(_delta):
 	if respawn_seconds > 0 and _respawn_timer != -1:
 		if _respawn_timer > respawn_seconds:
 			# Show and re-enable the object.


### PR DESCRIPTION
# Description of changes
Makes bottles respawn 30 seconds after being collected.

The respawn functionality was added to the `Pickup` class, since powerup stars (wing/metal/vanish) also need to respawn after collection.

# Reviewer(s)
@GTcreyon @jaschutte 

# Issue(s)
Closes #78