### PR TITLE
Light refinement to item sound infrastructure

### DIFF
--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -71,9 +71,7 @@ func _pickup_id_setup() -> void:
 func _pickup_sound():
 	if sfx != null:
 		# Find an object we know will survive this object's destruction.
-		var safe_sfx_root = get_parent()
-		if parent_is_root:
-			safe_sfx_root = safe_sfx_root.get_parent()
+		var safe_sfx_root = $"/root/Main"
 		# Anchor the sound source to that, then play it.
 		ResidualSFX.new_from_existing(sfx, safe_sfx_root)
 


### PR DESCRIPTION
# Description of changes
Attach residual SFX to scene root instead of item's parent (or parent's parent), just to make sure it's as safe as possible.

# Issue(s)
Amends #89 