### PR TITLE
Don't version desktop.ini files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ export_presets.cfg
 data_*/
 main.tscn
 
+# Windows-specific ignores
+desktop.ini
+
 # IDE-specific ignores
 .vscode/*
 


### PR DESCRIPTION
# Description of changes
Add `desktop.ini` to the .gitignore.

For context, `desktop.ini` files are auto-generated by Windows Explorer to control the way folders are shown. That seems kind of personal, not to mention completely irrelevant to Mac+Linux users.


# Issue(s)
N/A