### PR TITLE
Allow Show Timer button to be bound

### DIFF
--- a/classes/global/singleton/singleton.gd
+++ b/classes/global/singleton/singleton.gd
@@ -26,6 +26,7 @@ const WHITELISTED_ACTIONS = [
 	"zoom-",
 	"semi",
 	"reset",
+	"timer_show",
 	"volume_music+",
 	"volume_music-",
 	"volume_sfx+",

--- a/classes/global/singleton/singleton.gd
+++ b/classes/global/singleton/singleton.gd
@@ -197,7 +197,7 @@ func get_input_map_json_saved():
 
 func load_input_map(input_json):
 	var load_dict: Dictionary = parse_json(input_json)
-	for key in Singleton.WHITELISTED_ACTIONS:
+	for key in WHITELISTED_ACTIONS:
 		InputMap.action_erase_events(key)
 		# Skip unbound actions
 		if !load_dict.has(key):

--- a/classes/global/singleton/singleton.gd
+++ b/classes/global/singleton/singleton.gd
@@ -196,9 +196,12 @@ func get_input_map_json_saved():
 
 
 func load_input_map(input_json):
-	var load_dict = parse_json(input_json)
-	for key in load_dict:
+	var load_dict: Dictionary = parse_json(input_json)
+	for key in Singleton.WHITELISTED_ACTIONS:
 		InputMap.action_erase_events(key)
+		# Skip unbound actions
+		if !load_dict.has(key):
+			continue
 		for action in load_dict[key]:
 			var type = action[0]
 			var body = action.substr(2)

--- a/gui/timer/timer.gd
+++ b/gui/timer/timer.gd
@@ -11,9 +11,6 @@ var frames: int = 0
 var split_frames: int = 0
 var running = false
 
-#func _ready():
-#	total.margin_right = get_font("font").get_string_size("0:00.0000").x + 10
-
 
 func format_time(overall_seconds):
 	var ms = floor(fmod(overall_seconds, 1) * 1000)
@@ -44,6 +41,9 @@ func format_time(overall_seconds):
 
 
 func _physics_process(_delta):
+	if Input.is_action_just_pressed("timer_show"):
+		visible = !visible
+	
 	if Input.is_action_just_pressed("reset") and get_tree().get_current_scene().get_filename().count("tutorial") and !get_tree().paused and Singleton.timer.visible:
 		Singleton.get_node("Timer").frames = 0
 		Singleton.get_node("Timer").split_frames = 0
@@ -59,7 +59,8 @@ func _physics_process(_delta):
 		var txt = format_time(round(frames / 60.0 * 1000.0) / 1000.0)
 		total.text = txt[0]
 		total_ms.text = txt[1]
-	
+
+
 func split_timer():
 	var txt = format_time(split_frames / 60.0)
 	split_ref.text = txt[0] + txt[1]

--- a/project.godot
+++ b/project.godot
@@ -595,8 +595,7 @@ feedback={
 }
 reset={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
- ]
+"events": [  ]
 }
 ld_queue+={
 "deadzone": 0.5,
@@ -673,6 +672,10 @@ ld_cancel_placement={
 "deadzone": 0.5,
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
  ]
+}
+timer_show={
+"deadzone": 0.5,
+"events": [  ]
 }
 
 [input_devices]


### PR DESCRIPTION
# Description of changes
Adds a bind option for Show Timer. Also unbinds Reset Run by default.
This allows speedrunners to bind these manually, while not interfering with casual players.

# Issue(s)
Closes #100