### PR TITLE
Fix position of player's feet during dive state

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1510,21 +1510,13 @@ func dive_correct(factor): # Correct the player's origin position when diving
 	# warning-ignore:return_value_discarded
 	move_and_slide(Vector2(0, DIVE_CORRECTION * factor * 60), Vector2(0, -1))
 	if factor == -1:
+		feet_area.position.y = 0
 		dust.position.y = 11.5
 		ground_failsafe_check.position.y = 17
 	else:
+		feet_area.position.y = -DIVE_CORRECTION
 		dust.position.y = 11.5 - DIVE_CORRECTION
 		ground_failsafe_check.position.y = 17 - DIVE_CORRECTION
-#	base_modifier.add_modifier(
-#		camera,
-#		"position",
-#		"dive_correction",
-#		Vector2(
-#			0,
-#			min(0, -DIVE_CORRECTION * factor)
-#		)
-#	)
-	# camera.position.y = min(0, -set_dive_correct * factor)
 
 
 func play_sfx(type, group):

--- a/classes/player/player.tscn
+++ b/classes/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=77 format=2]
+[gd_scene load_steps=76 format=2]
 
 [ext_resource path="res://classes/dejitter_group/dejitter_group.gd" type="Script" id=1]
 [ext_resource path="res://classes/player/fludd_spray_renderer.gd" type="Script" id=2]


### PR DESCRIPTION
# Description of changes
Corrects the position of the player's feet area during a dive state to ensure they properly trigger collisions.

# Issue(s)
Closes #102