### PR TITLE
Fix water not rendering on Android

### DIFF
--- a/classes/water/water.gd
+++ b/classes/water/water.gd
@@ -142,7 +142,7 @@ func on_ready():
 	var img_texture = ImageTexture.new()
 	var img = Image.new()
 	# Note: is there a less space needing format? it really only needs to store 2 colors, so 1 bit image format would work
-	img.create(max_x, max_y, false, Image.FORMAT_RGB8)
+	img.create(max_x, max_y, false, Image.FORMAT_L8)
 	# Make the texture white
 	img.fill(Color(1, 1, 1, 1))
 	img_texture.create_from_image(img)

--- a/classes/water/water_viewport.gd
+++ b/classes/water/water_viewport.gd
@@ -58,7 +58,7 @@ func refresh():
 	
 	# Shader copy time
 	var tex = ImageTexture.new()
-	tex.create(viewport.size.x, viewport.size.y, Image.FORMAT_RGB8)
+	tex.create(viewport.size.x, viewport.size.y, Image.FORMAT_L8)
 	texture = tex
 	
 	water.color = Color(water_color.r, water_color.g, water_color.b, 1)


### PR DESCRIPTION
# Description of changes
Fix an issue where water polygons would not render on Android, due to their image textures being black.

The RGB8 format apparently has issues on Android, so L8 was used instead.

See: https://github.com/godotengine/godot/issues/35459

# Issue(s)
Closes #15