### PR TITLE
Fixed pickup crash bug

### DIFF
--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -96,7 +96,7 @@ func _pickup_sound():
 			ResidualSFX.new_from_existing(sfx, safe_sfx_root)
 		# Check to see if object should have an sfx, and if it does have an sfx.
 		elif sfx != null and !has_node(_sfx_path):
-			printerr("No SFXCollect Found :(")
+			printerr("This pickup should have SFXCollect, but it wasn't found. :(")
 	else:
 		sfx.play()
 

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -54,7 +54,12 @@ func assign_pickup_id(id) -> void:
 
 func pickup(body) -> void:
 	_award_pickup(body)
-	_pickup_sound()
+	
+	if respawn_seconds == 0.0:
+		_pickup_sound()
+	else:
+		sfx.play()
+	
 	_pickup_effect()
 	_kill_pickup()
 	if persistent_collect:
@@ -85,7 +90,7 @@ func _pickup_id_setup() -> void:
 
 
 func _pickup_sound():
-	if sfx != null:
+	if sfx != null and has_node("SFXCollect"):
 		# Find an object we know will survive this object's destruction.
 		var safe_sfx_root = $"/root/Main"
 		# Anchor the sound source to that, then play it.

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -54,12 +54,7 @@ func assign_pickup_id(id) -> void:
 
 func pickup(body) -> void:
 	_award_pickup(body)
-	
-	if respawn_seconds == 0.0:
-		_pickup_sound()
-	else:
-		sfx.play()
-	
+	_pickup_sound()
 	_pickup_effect()
 	_kill_pickup()
 	if persistent_collect:
@@ -90,11 +85,19 @@ func _pickup_id_setup() -> void:
 
 
 func _pickup_sound():
-	if sfx != null and has_node("SFXCollect"):
-		# Find an object we know will survive this object's destruction.
-		var safe_sfx_root = $"/root/Main"
-		# Anchor the sound source to that, then play it.
-		ResidualSFX.new_from_existing(sfx, safe_sfx_root)
+	# Check to make sure the object is killable.
+	if respawn_seconds == 0.0:
+		# If the has_node() check did not exist, it could pass an arg previously freed.
+		if sfx != null and has_node("SFXCollect"):
+			# Find an object we know will survive this object's destruction.
+			var safe_sfx_root = $"/root/Main"
+			# Anchor the sound source to that, then play it.
+			ResidualSFX.new_from_existing(sfx, safe_sfx_root)
+		# Some pickups i.e. coins, have no sfx at all. We need to run both checks.
+		elif sfx != null and !has_node("SFXCollect"):
+			printerr("No SFXCollect Found :(")
+	else:
+		sfx.play()
 
 
 func _kill_pickup() -> void:

--- a/classes/pickup/pickup.gd
+++ b/classes/pickup/pickup.gd
@@ -87,14 +87,15 @@ func _pickup_id_setup() -> void:
 func _pickup_sound():
 	# Check to make sure the object is killable.
 	if respawn_seconds == 0.0:
-		# If the has_node() check did not exist, it could pass an arg previously freed.
-		if sfx != null and has_node("SFXCollect"):
+		# Check to see if sfx should exist, and does exist.
+		# sfx will exist if it should, but the second condition is a failsafe in case it doesn't.
+		if sfx != null and has_node(_sfx_path):
 			# Find an object we know will survive this object's destruction.
 			var safe_sfx_root = $"/root/Main"
 			# Anchor the sound source to that, then play it.
 			ResidualSFX.new_from_existing(sfx, safe_sfx_root)
-		# Some pickups i.e. coins, have no sfx at all. We need to run both checks.
-		elif sfx != null and !has_node("SFXCollect"):
+		# Check to see if object should have an sfx, and if it does have an sfx.
+		elif sfx != null and !has_node(_sfx_path):
 			printerr("No SFXCollect Found :(")
 	else:
 		sfx.play()


### PR DESCRIPTION
Changed the Pickup class to contain a has_node() check in the _pickup_sound() method, and a check to ensure the object would not respawn before reparenting the AudioPlayer.

Closes #113 