### PR TITLE
Fix bind reset not saving

### DIFF
--- a/gui/pause/options/reset_binds.gd
+++ b/gui/pause/options/reset_binds.gd
@@ -2,5 +2,7 @@ extends TextureButton
 
 
 func _on_ResetBinds_pressed():
-	Singleton.load_input_map(Singleton.default_input_map)
+	var map = Singleton.default_input_map
+	Singleton.load_input_map(map)
+	Singleton.save_input_map(map)
 	Singleton.get_node("SFX/Back").play()


### PR DESCRIPTION
# Description of changes
Fixes an issue where resetting keybinds to default does not result in changes being saved.