### PR TITLE
Fix Paratroopa memory leak

### DIFF
--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -39,7 +39,7 @@ func _ready():
 
 
 func _exit_tree():
-	#Prevent memory leakage
+	# Prevent memory leak
 	if is_instance_valid(koopa):
 		koopa.queue_free()
 	if is_instance_valid(shell):

--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -37,6 +37,7 @@ func _ready():
 		frame = hash(position.x + position.y * PI) % 6
 		playing = !disabled
 
+
 func _exit_tree():
 	#Prevent memory leakage
 	if is_instance_valid(koopa):

--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -37,6 +37,13 @@ func _ready():
 		frame = hash(position.x + position.y * PI) % 6
 		playing = !disabled
 
+func _exit_tree():
+	#Prevent memory leakage
+	if is_instance_valid(koopa):
+		koopa.queue_free()
+	if is_instance_valid(shell):
+		shell.queue_free()
+
 
 func _on_TopCollision_body_entered(body):
 	if body.is_spinning():


### PR DESCRIPTION
# Description of changes
Fixes a memory leak found in paratroopa.gd, where orphan nodes weren't being freed.

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #123 