### PR TITLE
Upgrade ResidualSFX.new_from_existing error handling

### DIFF
--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -50,14 +50,12 @@ func _wander():
 
 
 func _hurt_stomp(area):
-	ResidualSFX.new_from_existing(sfx_stomp, get_parent())
 	var body = area.get_parent()
 	body.vel.y = -5
 	into_shell(0)
 
 
 func _hurt_struck(body):
-	ResidualSFX.new_from_existing(sfx_struck, get_parent())
 	if body.global_position.x < global_position.x:
 		into_shell(5)
 	else:

--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -50,12 +50,14 @@ func _wander():
 
 
 func _hurt_stomp(area):
+	ResidualSFX.new_from_existing(sfx_stomp, get_parent())
 	var body = area.get_parent()
 	body.vel.y = -5
 	into_shell(0)
 
 
 func _hurt_struck(body):
+	ResidualSFX.new_from_existing(sfx_struck, get_parent())
 	if body.global_position.x < global_position.x:
 		into_shell(5)
 	else:

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -49,8 +49,9 @@ static func new_from_existing (
 		# Reparent to the scene root.
 		_move_node_to(sfx, scene_root)
 	
-	# Make the sfx player destroy on playback (if desired)
-	if destroy_on_finished:
+	# Make the sfx player destroy on playback (if desired).
+	# (and if it's not already set that way--Godot complains otherwise).
+	if destroy_on_finished and !sfx.is_connected("finished", sfx, "queue_free"):
 		sfx.connect("finished", sfx, "queue_free")
 	# Lesgo
 	sfx.play()

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -29,11 +29,12 @@ static func new_from_existing (
 	destroy_on_finished = true
 ):
 	# VALIDATE: Is the passed node an audio source?
-	assert(
-		sfx is AudioStreamPlayer or sfx is AudioStreamPlayer2D \
-			or sfx is AudioStreamPlayer3D, # just for completeness
-		"Attempted to create a residual sound from a non-sound node."
-	)
+	if not (sfx is AudioStreamPlayer or sfx is AudioStreamPlayer2D \
+		or sfx is AudioStreamPlayer3D # So we can throw special error later
+	):
+		push_error("Attempted to create a residual sound from a non-sound node.")
+		return
+	
 	# VALIDATE: Is the passed audio source either 2D or positionless?
 	if sfx is AudioStreamPlayer3D:
 		push_error("""Created ResidualSFX from a 3D audio source.

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -24,10 +24,22 @@ func _init(sound: AudioStream, pos: Vector2):
 # Takes an existing AudioStreamPlayer(2D) and makes it act like a ResidualSFX
 # (outlive its parent, optionally destroy on finish).
 static func new_from_existing (
-	sfx,
+	sfx: Node,
 	scene_root: Node,
 	destroy_on_finished = true
 ):
+	# VALIDATE: Is the passed node an audio source?
+	assert(
+		sfx is AudioStreamPlayer or sfx is AudioStreamPlayer2D \
+			or sfx is AudioStreamPlayer3D, # just for completeness
+		"Attempted to create a residual sound from a non-sound node."
+	)
+	# VALIDATE: Is the passed audio source either 2D or positionless?
+	if sfx is AudioStreamPlayer3D:
+		push_error("""Created ResidualSFX from a 3D audio source.
+			The codebase is not designed to handle 3D positions, so this
+			audio source's position will be left undefined.""")
+	
 	if sfx is Node2D:
 		# Reparent to scene root, while preserving global position.
 		var sound_pos = sfx.global_position

--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -51,8 +51,14 @@ static func new_from_existing (
 	
 	# Make the sfx player destroy on playback (if desired).
 	# (and if it's not already set that way--Godot complains otherwise).
-	if destroy_on_finished and !sfx.is_connected("finished", sfx, "queue_free"):
-		sfx.connect("finished", sfx, "queue_free")
+	if destroy_on_finished:
+		# VALIDATE: The SFX hasn't been set to destroy itself already, right?
+		if sfx.is_connected("finished", sfx, "queue_free"):
+			push_error("""Set SFX to destroy on finished that was already set to destroy on finish.
+				Double-check that the SFX isn't being residualized twice.""")
+		# If not, we're all set to set it up like that.
+		else:
+			sfx.connect("finished", sfx, "queue_free")
 	# Lesgo
 	sfx.play()
 


### PR DESCRIPTION
# Description of changes
Upgrades `ResidualSFX.new_from_existing` to handle more errors, better.

In particular, it now does the following:

- Crashes if the node it was given is not an audio source. (This can be downgraded to an error if needed.)
- Prints an error if the node it was given is an `AudioStreamPlayer3D`. Since the game is 2D, these probably shouldn't be in use anyway.
- Prints an error if the destroy-on-finished-playing signal is connected twice. This situation already errors, but handling it manually lets us give more specific information: what exactly is going wrong, what's been known to cause this before, where to check to try and fix it.

# Issue(s)
Was supposed to deal with #130. It didn't, but it should still be helpful in fixing that bug.