### PR TITLE
Fix lingering hitbox in Parakoopa

### DIFF
--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -60,7 +60,7 @@ func _on_TopCollision_body_entered(body):
 			body.vel.x *= 1.2
 			get_parent().call_deferred("add_child", koopa)
 			$TopCollision.set_deferred("monitoring", false)
-			$Damage.monitoring = false
+			$Damage.set_deferred("monitoring", false)
 			set_deferred("visible", false)
 			visible = false
 
@@ -91,7 +91,7 @@ func spawn_shell(body):
 	else:
 		shell.vel.x = -5
 	$TopCollision.set_deferred("monitoring", false)
-	$Damage.monitoring = false
+	$Damage.set_deferred("monitoring", false)
 	set_deferred("visible", false)
 
 


### PR DESCRIPTION
# Description of changes
Change parakoopa.gd's damage.monitoring assignment to be deferred since Godot doesn't like it when you change an area's monitoring status in a signal.

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #127.