### PR TITLE
Fix Koopas spawning multiple shells when being struck

### DIFF
--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -57,6 +57,10 @@ func _hurt_stomp(area):
 
 
 func _hurt_struck(body):
+	if struck: # Enemy has already been struck
+		return
+
+	struck = true
 	ResidualSFX.new_from_existing(sfx_struck, get_parent())
 	if body.global_position.x < global_position.x:
 		into_shell(5)


### PR DESCRIPTION
# Description of changes
<!-- Add in your changes and the importance of everything here -->
Checks if Koopas have already been struck before allowing a shell to spawn.

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #130.