### PR TITLE
Layer FLUDD box behind the player

### DIFF
--- a/classes/pickup/fludd_box/fludd_box.tscn
+++ b/classes/pickup/fludd_box/fludd_box.tscn
@@ -152,6 +152,7 @@ volume_db = -8.0
 bus = "SFX"
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
+z_index = -1
 frames = SubResource( 2 )
 animation = "stand_hover"
 playing = true


### PR DESCRIPTION
# Description of changes
Changes the Z-index of the FLUDD box to layer it behind the player instead of in front.