### PR TITLE
Fix broken quote blocks in feedback menu

### DIFF
--- a/scenes/menus/feedback/feedback.gd
+++ b/scenes/menus/feedback/feedback.gd
@@ -80,7 +80,7 @@ func _take_screenshot() -> PoolByteArray:
 
 func _assemble_message() -> String:
 	var msg = "**Description:**\n> "
-	msg += description.text
+	msg += description.text.replace("\n", "\n> ")
 	
 	msg += "\n**Categories:**"
 	var categories = ""


### PR DESCRIPTION
# Description of changes
Previously, the quote block for the Description section in the feedback menu would only quote the first line. This fixes that, allowing all lines to be included in the quote block.