### PR TITLE
Fix spin sound not stopping properly

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1327,9 +1327,10 @@ const STAND_BOX_EXTENTS = Vector2(6, 14.5)
 const DIVE_BOX_POS = Vector2(0, 10)
 const DIVE_BOX_EXTENTS = Vector2(6, 6)
 func switch_state(new_state):
+	# Always pause spin sfx
+	spin_sfx.stream_paused = true
 	# If spin just ended, adjust SFX accordingly.
 	if state == S.SPIN:
-		spin_sfx.stop()
 		if swimming:
 			play_sfx("spin_end", "water")
 	
@@ -1352,7 +1353,6 @@ func switch_state(new_state):
 
 	
 	# On any state change, reset the following things:
-	spin_sfx.stop()
 	pound_state = Pound.NONE
 	clear_rotation_origin()
 
@@ -1401,6 +1401,7 @@ func play_sfx(type, group):
 		"spin", "spin_end":
 			spin_sfx.stream = sound
 			spin_sfx.play(0)
+			spin_sfx.stream_paused = false
 
 
 const TERRAIN_MASK = 0b111111110000000000000000

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1328,7 +1328,7 @@ const DIVE_BOX_POS = Vector2(0, 10)
 const DIVE_BOX_EXTENTS = Vector2(6, 6)
 func switch_state(new_state):
 	# Always pause spin sfx
-	spin_sfx.stream_paused = true
+	spin_sfx.playing = false
 	# If spin just ended, adjust SFX accordingly.
 	if state == S.SPIN:
 		if swimming:
@@ -1400,8 +1400,7 @@ func play_sfx(type, group):
 			thud.play(0)
 		"spin", "spin_end":
 			spin_sfx.stream = sound
-			spin_sfx.play(0)
-			spin_sfx.stream_paused = false
+			spin_sfx.playing = true
 
 
 const TERRAIN_MASK = 0b111111110000000000000000

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1327,8 +1327,9 @@ const STAND_BOX_EXTENTS = Vector2(6, 14.5)
 const DIVE_BOX_POS = Vector2(0, 10)
 const DIVE_BOX_EXTENTS = Vector2(6, 6)
 func switch_state(new_state):
-	# Always pause spin sfx
-	spin_sfx.playing = false
+	# Always pause AND stop spin SFX
+	spin_sfx.stop()
+	spin_sfx.stream_paused = true
 	# If spin just ended, adjust SFX accordingly.
 	if state == S.SPIN:
 		if swimming:
@@ -1400,7 +1401,8 @@ func play_sfx(type, group):
 			thud.play(0)
 		"spin", "spin_end":
 			spin_sfx.stream = sound
-			spin_sfx.playing = true
+			spin_sfx.play(0)
+			spin_sfx.stream_paused = false
 
 
 const TERRAIN_MASK = 0b111111110000000000000000

--- a/gui/theme_gui.tres
+++ b/gui/theme_gui.tres
@@ -1,24 +1,17 @@
-[gd_resource type="Theme" load_steps=20 format=2]
+[gd_resource type="Theme" load_steps=15 format=2]
 
 [ext_resource path="res://fonts/bylight/bylight.tres" type="DynamicFont" id=1]
-[ext_resource path="res://gui/scroll/scroll_v_grabber_hover.png" type="Texture" id=2]
-[ext_resource path="res://gui/scroll/scroll_v_back.png" type="Texture" id=3]
-[ext_resource path="res://gui/scroll/scroll_v_grabber_press.png" type="Texture" id=4]
-[ext_resource path="res://gui/scroll/scroll_v_grabber.png" type="Texture" id=5]
 [ext_resource path="res://gui/boxes/menu_box_normal.tres" type="StyleBox" id=6]
 [ext_resource path="res://gui/dropdown_arrow.png" type="Texture" id=7]
 [ext_resource path="res://gui/dialog/sign_box.tres" type="StyleBox" id=8]
 [ext_resource path="res://gui/boxes/menu_box_hover.tres" type="StyleBox" id=9]
 [ext_resource path="res://gui/boxes/menu_box_pressed.tres" type="StyleBox" id=10]
 [ext_resource path="res://gui/boxes/menu_box_drop.tres" type="StyleBox" id=11]
-[ext_resource path="res://gui/radio.png" type="Texture" id=12]
 
 [sub_resource type="AtlasTexture" id=8]
-atlas = ExtResource( 12 )
 region = Rect2( 0, 0, 14, 15 )
 
 [sub_resource type="AtlasTexture" id=9]
-atlas = ExtResource( 12 )
 region = Rect2( 0, 15, 14, 15 )
 
 [sub_resource type="StyleBoxEmpty" id=4]
@@ -28,7 +21,6 @@ content_margin_top = 2.0
 content_margin_bottom = 2.0
 
 [sub_resource type="StyleBoxTexture" id=3]
-texture = ExtResource( 5 )
 region_rect = Rect2( 0, 0, 11, 13 )
 margin_left = 6.0
 margin_right = 6.0
@@ -36,7 +28,6 @@ margin_top = 6.0
 margin_bottom = 8.0
 
 [sub_resource type="StyleBoxTexture" id=5]
-texture = ExtResource( 2 )
 region_rect = Rect2( 0, 0, 11, 13 )
 margin_left = 5.0
 margin_right = 5.0
@@ -44,7 +35,6 @@ margin_top = 6.0
 margin_bottom = 8.0
 
 [sub_resource type="StyleBoxTexture" id=6]
-texture = ExtResource( 4 )
 region_rect = Rect2( 1, 0, 11, 13 )
 margin_left = 5.0
 margin_right = 5.0
@@ -52,7 +42,6 @@ margin_top = 8.0
 margin_bottom = 6.0
 
 [sub_resource type="StyleBoxTexture" id=7]
-texture = ExtResource( 3 )
 region_rect = Rect2( 0, 0, 13, 26 )
 margin_left = 3.0
 margin_right = 3.0

--- a/project.godot
+++ b/project.godot
@@ -243,6 +243,11 @@ _global_script_classes=[ {
 "class": "Warp",
 "language": "GDScript",
 "path": "res://classes/global/singleton/warp.gd"
+}, {
+"base": "Polygon2D",
+"class": "WindowWarp",
+"language": "GDScript",
+"path": "res://classes/global/singleton/window_warp.gd"
 } ]
 _global_script_class_icons={
 "AutoPlaySprite": "",
@@ -291,7 +296,8 @@ _global_script_class_icons={
 "TileToPoly": "",
 "TippingLog": "",
 "Toad": "",
-"Warp": ""
+"Warp": "",
+"WindowWarp": ""
 }
 
 [application]


### PR DESCRIPTION
# Description of changes
For some reason, sfx.stop() doesn't work when used on the same frame as sfx.play(). Setting stream_paused doesn't seem to have any issues though, so this fix makes spin_sfx use that instead. 


# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #101 