### PR TITLE
End FLUDD sound when switching off hover nozzle

### DIFF
--- a/classes/player/fludd_sprite.gd
+++ b/classes/player/fludd_sprite.gd
@@ -168,28 +168,41 @@ func _process(_delta) -> void:
 
 
 func _hover_spray() -> void:
+	# Spray can last forever if diving or swimming; play looping sound.
 	if player_body.state == player_body.S.DIVE or player_body.swimming:
+		# Ensure that the non-looping sound doesn't play.
 		hover_sfx.stop()
+		
+		# Spray is going. Play the sound.
 		if player_body.fludd_strain:
 			if !hover_loop_sfx.playing:
 				hover_loop_sfx.play(hover_sound_position)
+		# Spray is not going. Don't play, but remember position in loop.
 		else:
 			hover_sound_position = hover_loop_sfx.get_playback_position()
 			hover_loop_sfx.stop()
+	# Spray lasts a finite duration in midair; play sound which ends.
 	else:
+		# Ensure that the looping sound doesn't play.
 		hover_loop_sfx.stop()
+		
+		# Reset sound when reaching the end of the power bar.
 		if player_body.fludd_power > 99:
 			hover_sound_position = 0
 			hover_sfx.stop()
-			
+		
+		# Play sound if appropriate.
 		if player_body.fludd_strain:
 			if !hover_sfx.playing:
 				hover_sfx.play(hover_sound_position)
+		# Stop sound. Remember where we stopped, if midway through the power bar.
 		else:
+			# Memorize position, or reset it if power is maxed out.
 			if player_body.fludd_power < 100:
 				hover_sound_position = hover_sfx.get_playback_position()
 			else:
 				hover_sound_position = 0
+			
 			if !player_body.fludd_spraying():
 				hover_sfx.stop()
 	

--- a/classes/player/fludd_sprite.gd
+++ b/classes/player/fludd_sprite.gd
@@ -168,13 +168,15 @@ func _process(_delta) -> void:
 
 
 func _hover_spray() -> void:
+	var is_hover_fludd = player_body.current_nozzle == Singleton.Nozzles.HOVER
+	
 	# Spray can last forever if diving or swimming; play looping sound.
 	if player_body.state == player_body.S.DIVE or player_body.swimming:
 		# Ensure that the non-looping sound doesn't play.
 		hover_sfx.stop()
 		
 		# Spray is going. Play the sound.
-		if player_body.fludd_strain:
+		if player_body.fludd_strain and is_hover_fludd:
 			if !hover_loop_sfx.playing:
 				hover_loop_sfx.play(hover_sound_position)
 		# Spray is not going. Don't play, but remember position in loop.
@@ -186,8 +188,9 @@ func _hover_spray() -> void:
 		# Ensure that the looping sound doesn't play.
 		hover_loop_sfx.stop()
 		
-		# Reset sound when reaching the end of the power bar.
-		if player_body.fludd_power > 99:
+		# Reset sound when reaching the end of the power bar,
+		# or when switching off of the hover nozzle.
+		if player_body.fludd_power > 99 or !is_hover_fludd:
 			hover_sound_position = 0
 			hover_sfx.stop()
 		

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1246,7 +1246,8 @@ func manage_crouch_reset() -> void:
 
 
 func switch_fludd():
-	var save_nozzle = current_nozzle
+	var last_nozzle = current_nozzle
+	# Switch to next nozzle, bypassing nozzles not currently held.
 	current_nozzle += 1
 	while (
 		(
@@ -1256,9 +1257,11 @@ func switch_fludd():
 		or current_nozzle == 0
 	):
 		current_nozzle += 1
+	# If reached the end, revert to no nozzle.
 	if current_nozzle == 4:
 		current_nozzle = 0
-	if current_nozzle != save_nozzle:
+	# If nozzle actually changed, set it up and play effects.
+	if current_nozzle != last_nozzle:
 		fludd_strain = false
 		switch_sfx.play()
 


### PR DESCRIPTION
# Description of changes
When switching FLUDD nozzles mid-spray, the spray sounds would continue, at least when in air. The spray sound now ends appropriately.

Switching mid-spray while diving was not tested, but a code inspection suggests the same issue was present, so the issue was also fixed there.

# Issue(s)
Fixes a bug reported by Vexxter in the #playtesting channel.