### PR TITLE
Fix animation not being set properly when reading signs

### DIFF
--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -26,6 +26,9 @@ func _interact_with(body):
 	body.locked = true
 	body.sign_frames = 1
 	
+	# Initiate the sign-reading animation
+	body.sprite.reading_sign = back_sprite
+	
 	# Disable any active sfx on the player
 	body.start_interaction()
 	dialog.load_lines(lines)

--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -25,8 +25,6 @@ func _interact_with(body):
 	body.vel = Vector2.ZERO
 	body.locked = true
 	body.sign_frames = 1
-	if back_sprite:
-		body.sprite.trigger_anim("back")
 	
 	# Disable any active sfx on the player
 	body.start_interaction()

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -24,7 +24,7 @@ var last_grounded: bool = true
 var last_flip_ending: bool = false # parent.triple_flip_frames >= TRIPLE_FLIP_HALFWAY
 var last_pound_state: int = PlayerCharacter.Pound.SPIN
 var last_frame = 0 # Used mainly during walking animation
-
+var reading_sign: bool = false # True if the player is reading a sign
 var slow_spin_timer: float = 0 # Frames of progress through the slow spin
 var rng = RandomNumberGenerator.new()
 
@@ -346,7 +346,7 @@ func _state_neutral(old_state: int, old_swimming: bool) -> String:
 	
 	state_changed = state_changed or (old_swimming and !parent.swimming)
 	
-	if parent.read_pos_x != INF:
+	if reading_sign:
 		return "back"
 	
 	if parent.get_ground_state() and !last_grounded:

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -346,6 +346,9 @@ func _state_neutral(old_state: int, old_swimming: bool) -> String:
 	
 	state_changed = state_changed or (old_swimming and !parent.swimming)
 	
+	if parent.read_pos_x != INF:
+		return "back"
+	
 	if parent.get_ground_state() and !last_grounded:
 		# Just hit the ground
 		if parent.get_walk_direction() == 0:

--- a/gui/dialog/dialog_box.gd
+++ b/gui/dialog/dialog_box.gd
@@ -220,6 +220,7 @@ func _physics_process(_delta):
 					active = false
 					player.read_pos_x = INF
 					player.locked = false
+					player.sprite.reading_sign = false
 					swoop_timer = 0
 					sfx_close.play()
 				else:


### PR DESCRIPTION
# Description of changes
Fixes an issue where reading a sign while spinning would cause the neutral animation to play instead.