### PR TITLE
Fix nozzle pickups layering in front of boxes

### DIFF
--- a/classes/pickup/fludd_box/fludd_pickup_hover.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_hover.tscn
@@ -31,6 +31,7 @@ persistent_collect = false
 nozzle_award = 1
 
 [node name="Sprite" type="Sprite" parent="Hover"]
+z_index = -1
 texture = ExtResource( 5 )
 script = ExtResource( 1 )
 

--- a/classes/pickup/fludd_box/fludd_pickup_rocket.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_rocket.tscn
@@ -32,6 +32,7 @@ nozzle_award = 2
 
 [node name="Sprite" type="Sprite" parent="Rocket"]
 position = Vector2( 0, -5 )
+z_index = -1
 texture = ExtResource( 3 )
 script = ExtResource( 1 )
 

--- a/classes/pickup/fludd_box/fludd_pickup_turbo.tscn
+++ b/classes/pickup/fludd_box/fludd_pickup_turbo.tscn
@@ -31,6 +31,7 @@ nozzle_award = 3
 
 [node name="Sprite" type="Sprite" parent="Turbo"]
 position = Vector2( 0, -3 )
+z_index = -1
 texture = ExtResource( 4 )
 script = ExtResource( 1 )
 


### PR DESCRIPTION
# Description of changes
Fixes an issue where FLUDD nozzle pickups would layer in front of the boxes they drop from, resulting in a flawed animation.