### PR TITLE
Fix bus of ResidualSFX

### DIFF
--- a/classes/misc/residual_sfx/residual_sfx.gd
+++ b/classes/misc/residual_sfx/residual_sfx.gd
@@ -9,6 +9,10 @@ func _ready():
 	# Set self up to self-destruct once the sound is finished.
 	# warning-ignore:return_value_discarded
 	connect("finished", self, "_on_ResidualSFX_finished")
+	
+	# Ensure we are on the SFX bus
+	bus = "SFX"
+	
 	play()
 
 


### PR DESCRIPTION
# Description of changes
Fixes an issue where ResidualSFXes created through `ResidualSFX.new()` would not be on the SFX bus, and as such would not be muted by Mute SFX.