### PR TITLE
Fix reverb carrying over between scenes

### DIFF
--- a/classes/global/singleton/singleton.gd
+++ b/classes/global/singleton/singleton.gd
@@ -285,3 +285,10 @@ func save_input_map(input_json):
 	file.open("user://controls.json", File.WRITE)
 	file.store_string(input_json) # minimize the amount of time spent with the file open
 	file.close()
+
+
+func reset_bus_effect(channel, effect_idx):
+	var bus_index = AudioServer.get_bus_index(channel)
+	var bus_effect = AudioServer.get_bus_effect(bus_index, effect_idx)
+	AudioServer.remove_bus_effect(bus_index, 0) # this just gets rid of any unwanted gunk stuck in the bus
+	AudioServer.add_bus_effect(bus_index, bus_effect, 0)

--- a/classes/misc/twirl_heart/twirl_heart.gd
+++ b/classes/misc/twirl_heart/twirl_heart.gd
@@ -15,7 +15,7 @@ func _physics_process(_delta):
 	if crossed_item:
 		if mario.hp < 8:
 			if timer >= 30:
-				mario.recieve_health(1)
+				mario.receive_health(1)
 				timer = 0
 			else:
 				timer += 1

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -178,7 +178,10 @@ onready var feet_area: Area2D = $Feet
 
 
 func _ready():
+	
 	switch_state(S.NEUTRAL) # reset state to avoid short mario glitch
+	
+	Singleton.reset_bus_effect("~Water Verb:", 0) # prevents garbage reverb
 	
 	# If we came from another scene, load our data from that scene.
 	if Singleton.warp_location != null:
@@ -1387,7 +1390,7 @@ func off_ground():
 	cancel_ground = true
 
 
-func recieve_health(amount):
+func receive_health(amount):
 	hp = clamp(hp + amount, 0, 8) # TODO - multi HP
 
 


### PR DESCRIPTION
# Description of changes
I added a `reset_bus_effect` function to the Singleton class, it resets a chosen bus effect in an audio bus. Additionally, I added a call to this function whenever the player is loaded. This is so any left over reverb is automatically cleared when you enter a new scene, preventing leftover garbage reverb from playing. I also fixed a minor typo.

# Issue(s)
Closes #168 