### PR TITLE
Update style guide docs reference while we're not on 4.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Example: `repo-clarify-styleguide`
 
 Delete branches once they've been merged, to keep the tree clean.
 ### Styling
-Follow the [Godot style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html) as closely as possible, albeit with the following alterations:
+Follow the [Godot style guide](https://docs.godotengine.org/en/3.5/tutorials/scripting/gdscript/gdscript_styleguide.html) as closely as possible, albeit with the following alterations:
 * The keywords `and` and `or` are used in place of the C-like `&&` and `||` as-per the style guide, however we use the `!` symbol as opposed to `not`, to allow easier reading of more complex boolean expressions. So, `if !foo and !bar:`
 * When unfolding longer lines we only use *one* tab, not two. This is contrary to the Godot style guide.
 ### Documentation


### PR DESCRIPTION
# Description of changes
Since we're not yet on the 4.0 branch, updates the link to the Godot style guide to explicitly point to version 3.5. Hopefully we remember to update this when we eventually switch to 4.1

# Issue(s)
N/A