### PR TITLE
Background terrain support

### DIFF
--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -41,7 +41,7 @@ func add_full(poly: PoolVector2Array):
 	var type_ids: Dictionary = resolve_edge_types(root.edge_types, poly)
 	var latest_index = 0
 	
-	# Draw each edge type in draw order--first sides, then bottom, finally top.
+	# Draw each edge type from back to front: sides, bottom, finally top.
 	# Begin with sides.
 	latest_index = 0
 	# Iterate the polygon until all chains of top-edge have been found

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -282,7 +282,7 @@ func get_connected_lines_directional(
 		
 		if (
 			# Has this segment's type been specifically set to the desired type?
-			check_override(ind, type_id, overrides)
+			overrides.has(ind) and overrides[ind] == type_id
 		) or (
 			# If type is not set, is it within the range this type normally is?
 			!overrides.has(ind) and check_line_angle(angle)
@@ -351,11 +351,6 @@ func get_connected_lines_overrides(
 func _normal_of_segment(vert: Vector2, next: Vector2) -> Vector2:
 	# "Up" relative to segment (vert, next).
 	return vert.direction_to(next).tangent()
-
-
-# Check if the type override for the given line index matches with the type id given
-func check_override(index: int, type_id: int, override_list: Dictionary) -> bool:
-	return override_list.has(index) and override_list[index] == type_id
 
 
 func check_line_angle(angle: float) -> bool:

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -1,6 +1,11 @@
 tool
 class_name TerrainBorder
 extends Node2D
+# Handles drawing of terrain polygons' border graphics, except for
+# the endcaps of top edges.
+#
+# Border graphics are always ordered with top edges (and endcaps) in front,
+# then bottom edges, then sides.
 
 enum EdgeType {
 	NONE,
@@ -13,7 +18,7 @@ const QUAD_RADIUS = 16
 
 onready var root = $".."
 onready var body_polygon: Polygon2D = $"../Body"
-onready var top_edges: TerrainBorderEndcaps = $"../TopEdges"
+onready var top_edges: TerrainBorderEndcaps = $"../TopEdgeEndcaps"
 
 
 func _draw():

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -61,7 +61,7 @@ func add_full(poly: PoolVector2Array):
 		# If the chain is valid, draw it.
 		if list.size() >= 2:
 			generate_polygons(list, root.edge, 0)
-
+	
 	# Now the bottom as well--same exact deal as the sides.
 	latest_index = 0
 	while latest_index != null:

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -34,6 +34,47 @@ func _draw():
 	top_edges.update()
 
 
+func add_full(poly: PoolVector2Array):
+	# Dictionary of segments which have had their type ID evaluated.
+	# Types are indexed by first vertex: overrides[3] will return the
+	# type ID of segment (3, 4).
+	var overrides: Dictionary = root.edge_types.duplicate()
+	
+	# Draw the top edge texture.
+	var latest_index = 0
+	# Iterate the polygon until all chains of top-edge have been found
+	# (including single-segment chains).
+	while latest_index != null:
+		# Find a single chain of segments with type ID == EdgeType.TOP.
+		var list = []
+		# Also store the last index in the chain, so we can start from there
+		# next iteration of the while loop.
+		latest_index = get_connected_lines_directional(list, overrides, root.up_direction, poly, latest_index, EdgeType.TOP)
+		
+		# Valid chains contain at least 2 vertices.
+		# If the chain is valid, draw it.
+		if list.size() >= 2:
+			generate_polygons_top(list)
+	
+	# Do the bottom as well--same exact deal.
+	latest_index = 0
+	while latest_index != null:
+		var list = []
+		latest_index = get_connected_lines_directional(list, overrides, root.down_direction, poly, latest_index, EdgeType.BOTTOM)
+		if list.size() >= 2:
+			generate_polygons(list, root.bottom, 2)
+
+	# Now the sides.
+	latest_index = 0
+	while latest_index != null:
+		var list = []
+		# All edges' type indices have been marked now. Don't check angle,
+		# just read the types we marked last time.
+		latest_index = get_connected_lines_overrides(list, overrides, poly, latest_index, EdgeType.SIDE)
+		if list.size() >= 2:
+			generate_polygons(list, root.edge, 1)
+
+
 func generate_polygons_top(lines, z_order = 2):
 	# First create quads from each line segment.
 	var quads = []
@@ -355,44 +396,3 @@ func _normal_of_segment(vert: Vector2, next: Vector2) -> Vector2:
 
 func check_line_angle(angle: float) -> bool:
 	return angle >= -root.max_deviation and angle <= root.max_deviation
-
-
-func add_full(poly: PoolVector2Array):
-	# Dictionary of segments which have had their type ID evaluated.
-	# Types are indexed by first vertex: overrides[3] will return the
-	# type ID of segment (3, 4).
-	var overrides: Dictionary = root.edge_types.duplicate()
-	
-	# Draw the top edge texture.
-	var latest_index = 0
-	# Iterate the polygon until all chains of top-edge have been found
-	# (including single-segment chains).
-	while latest_index != null:
-		# Find a single chain of segments with type ID == EdgeType.TOP.
-		var list = []
-		# Also store the last index in the chain, so we can start from there
-		# next iteration of the while loop.
-		latest_index = get_connected_lines_directional(list, overrides, root.up_direction, poly, latest_index, EdgeType.TOP)
-		
-		# Valid chains contain at least 2 vertices.
-		# If the chain is valid, draw it.
-		if list.size() >= 2:
-			generate_polygons_top(list)
-	
-	# Do the bottom as well--same exact deal.
-	latest_index = 0
-	while latest_index != null:
-		var list = []
-		latest_index = get_connected_lines_directional(list, overrides, root.down_direction, poly, latest_index, EdgeType.BOTTOM)
-		if list.size() >= 2:
-			generate_polygons(list, root.bottom, 2)
-
-	# Now the sides.
-	latest_index = 0
-	while latest_index != null:
-		var list = []
-		# All edges' type indices have been marked now. Don't check angle,
-		# just read the types we marked last time.
-		latest_index = get_connected_lines_overrides(list, overrides, poly, latest_index, EdgeType.SIDE)
-		if list.size() >= 2:
-			generate_polygons(list, root.edge, 1)

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -39,40 +39,40 @@ func add_full(poly: PoolVector2Array):
 	# Types are indexed by first vertex: overrides[3] will return the
 	# type ID of segment (3, 4).
 	var type_ids: Dictionary = resolve_edge_types(root.edge_types, poly)
-	
-	# Draw the top edge texture.
 	var latest_index = 0
+	
+	# Draw each edge type in draw order--first sides, then bottom, finally top.
+	# Begin with sides.
+	latest_index = 0
 	# Iterate the polygon until all chains of top-edge have been found
 	# (including single-segment chains).
 	while latest_index != null:
-		# Find a single chain of segments with type ID == EdgeType.TOP.
+		# Find a single chain of segments with type ID == EdgeType.SIDE.
 		var list = []
 		# Also store the last index in the chain, so we can start from there
 		# next iteration of the while loop.
-		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.TOP)
-		
+		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.SIDE)
 		# Valid chains contain at least 2 vertices.
 		# If the chain is valid, draw it.
 		if list.size() >= 2:
-			generate_polygons_top(list)
-	
-	# Do the bottom as well--same exact deal.
+			generate_polygons(list, root.edge, 0)
+
+	# Now the bottom as well--same exact deal as the sides.
 	latest_index = 0
 	while latest_index != null:
 		var list = []
 		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.BOTTOM)
 		if list.size() >= 2:
-			generate_polygons(list, root.bottom, 2)
-
-	# Now the sides.
+			generate_polygons(list, root.bottom, 0)
+	
+	# Now the top--which has a special polygon-gen function to make endcaps.
 	latest_index = 0
 	while latest_index != null:
 		var list = []
-		# All edges' type indices have been marked now. Don't check angle,
-		# just read the types we marked last time.
-		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.SIDE)
+		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.TOP)
+		
 		if list.size() >= 2:
-			generate_polygons(list, root.edge, 1)
+			generate_polygons_top(list, 0)
 
 
 func generate_polygons_top(lines, z_order = 2):

--- a/classes/solid/terrain/terrain_border.gd
+++ b/classes/solid/terrain/terrain_border.gd
@@ -1,11 +1,6 @@
 tool
 class_name TerrainBorder
 extends Node2D
-# Handles drawing of terrain polygons' border graphics, except for
-# the endcaps of top edges.
-#
-# Border graphics are always ordered with top edges (and endcaps) in front,
-# then bottom edges, then sides.
 
 enum EdgeType {
 	NONE,
@@ -18,7 +13,7 @@ const QUAD_RADIUS = 16
 
 onready var root = $".."
 onready var body_polygon: Polygon2D = $"../Body"
-onready var top_edges: TerrainBorderEndcaps = $"../TopEdgeEndcaps"
+onready var top_edges: TerrainBorderEndcaps = $"../TopEdges"
 
 
 func _draw():
@@ -43,41 +38,41 @@ func add_full(poly: PoolVector2Array):
 	# Dictionary of segments which have had their type ID evaluated.
 	# Types are indexed by first vertex: overrides[3] will return the
 	# type ID of segment (3, 4).
-	var overrides: Dictionary = root.edge_types.duplicate()
-	
-	# Draw the top edge texture.
+	var type_ids: Dictionary = resolve_edge_types(root.edge_types, poly)
 	var latest_index = 0
+	
+	# Draw each edge type from back to front: sides, bottom, finally top.
+	# Begin with sides.
+	latest_index = 0
 	# Iterate the polygon until all chains of top-edge have been found
 	# (including single-segment chains).
 	while latest_index != null:
-		# Find a single chain of segments with type ID == EdgeType.TOP.
+		# Find a single chain of segments with type ID == EdgeType.SIDE.
 		var list = []
 		# Also store the last index in the chain, so we can start from there
 		# next iteration of the while loop.
-		latest_index = get_connected_lines_directional(list, overrides, root.up_direction, poly, latest_index, EdgeType.TOP)
-		
+		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.SIDE)
 		# Valid chains contain at least 2 vertices.
 		# If the chain is valid, draw it.
 		if list.size() >= 2:
-			generate_polygons_top(list)
-	
-	# Do the bottom as well--same exact deal.
-	latest_index = 0
-	while latest_index != null:
-		var list = []
-		latest_index = get_connected_lines_directional(list, overrides, root.down_direction, poly, latest_index, EdgeType.BOTTOM)
-		if list.size() >= 2:
-			generate_polygons(list, root.bottom, 2)
+			generate_polygons(list, root.edge, 0)
 
-	# Now the sides.
+	# Now the bottom as well--same exact deal as the sides.
 	latest_index = 0
 	while latest_index != null:
 		var list = []
-		# All edges' type indices have been marked now. Don't check angle,
-		# just read the types we marked last time.
-		latest_index = get_connected_lines_overrides(list, overrides, poly, latest_index, EdgeType.SIDE)
+		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.BOTTOM)
 		if list.size() >= 2:
-			generate_polygons(list, root.edge, 1)
+			generate_polygons(list, root.bottom, 0)
+	
+	# Now the top--which has a special polygon-gen function to make endcaps.
+	latest_index = 0
+	while latest_index != null:
+		var list = []
+		latest_index = get_segment_chain(list, type_ids, poly, latest_index, EdgeType.TOP)
+		
+		if list.size() >= 2:
+			generate_polygons_top(list, 0)
 
 
 func generate_polygons_top(lines, z_order = 2):

--- a/classes/solid/terrain/terrain_border_endcaps.gd
+++ b/classes/solid/terrain/terrain_border_endcaps.gd
@@ -1,7 +1,6 @@
 tool
 class_name TerrainBorderEndcaps
 extends Node2D
-# Handles drawing the endcaps of terrain polygons' top edges.
 
 const QUAD_SIZE = 32 #2*TerrainBorder.QUAD_RADIUS
 

--- a/classes/solid/terrain/terrain_border_endcaps.gd
+++ b/classes/solid/terrain/terrain_border_endcaps.gd
@@ -1,6 +1,7 @@
 tool
 class_name TerrainBorderEndcaps
 extends Node2D
+# Handles drawing the endcaps of terrain polygons' top edges.
 
 const QUAD_SIZE = 32 #2*TerrainBorder.QUAD_RADIUS
 

--- a/classes/solid/terrain/terrain_polygon.gd
+++ b/classes/solid/terrain/terrain_polygon.gd
@@ -1,6 +1,8 @@
 tool
 class_name TerrainPolygon
 extends Polygon2D
+# Root node for terrain polygons. All terrain-polygon behavior can be controlled
+# from here.
 
 const COLLISION_LAYER_TERRAIN = 0
 
@@ -31,7 +33,7 @@ export var edge_types: Dictionary = {}
 
 var properties: Dictionary = {}
 
-onready var decorations: TerrainBorder = $Decorations
+onready var decorations: TerrainBorder = $Borders
 onready var collision_body: StaticBody2D = $Static
 onready var collision_shape: CollisionPolygon2D = $Static/Collision
 

--- a/classes/solid/terrain/terrain_polygon.gd
+++ b/classes/solid/terrain/terrain_polygon.gd
@@ -1,8 +1,6 @@
 tool
 class_name TerrainPolygon
 extends Polygon2D
-# Root node for terrain polygons. All terrain-polygon behavior can be controlled
-# from here.
 
 const COLLISION_LAYER_TERRAIN = 0
 
@@ -33,7 +31,7 @@ export var edge_types: Dictionary = {}
 
 var properties: Dictionary = {}
 
-onready var decorations: TerrainBorder = $Borders
+onready var decorations: TerrainBorder = $Decorations
 onready var collision_body: StaticBody2D = $Static
 onready var collision_shape: CollisionPolygon2D = $Static/Collision
 

--- a/classes/solid/terrain/terrain_polygon.gd
+++ b/classes/solid/terrain/terrain_polygon.gd
@@ -2,6 +2,8 @@ tool
 class_name TerrainPolygon
 extends Polygon2D
 
+const COLLISION_LAYER_TERRAIN = 0
+
 export var texture_spritesheet: Texture setget update_spritesheets
 
 var body: Texture = ImageTexture.new()
@@ -20,6 +22,8 @@ export var max_deviation: int = 60
 export var tint = false
 export var tint_color = Color(1, 1, 1, 0.5)
 
+export var solid = true
+
 # Manually set the type on each edge, rather than using the auto-generated one
 # Types are indexed by first vertex: edge_types[3] will return the
 # type ID of segment (3, 4).
@@ -28,7 +32,8 @@ export var edge_types: Dictionary = {}
 var properties: Dictionary = {}
 
 onready var decorations: TerrainBorder = $Decorations
-onready var collision: CollisionPolygon2D = $Static/Collision
+onready var collision_body: StaticBody2D = $Static
+onready var collision_shape: CollisionPolygon2D = $Static/Collision
 
 
 func _draw():
@@ -39,7 +44,11 @@ func _draw():
 	
 	# Update the collision polygon if not in editor.
 	if !Engine.editor_hint:
-		collision.polygon = polygon
+		# Update cols to match the terrain's designed shape.
+		collision_shape.polygon = polygon
+		
+		# Enable/disable the collision itself as appropriate.
+		collision_body.set_collision_layer_bit(COLLISION_LAYER_TERRAIN, solid)
 
 
 func set_glowing(should_glow):

--- a/classes/solid/terrain/terrain_polygon.tscn
+++ b/classes/solid/terrain/terrain_polygon.tscn
@@ -27,12 +27,11 @@ texture_spritesheet = ExtResource( 3 )
 [node name="Body" type="Polygon2D" parent="."]
 texture = SubResource( 2 )
 
-[node name="TopEdges" type="Node2D" parent="."]
-z_index = 2
-script = ExtResource( 10 )
-
 [node name="Decorations" type="Node2D" parent="."]
 script = ExtResource( 4 )
+
+[node name="TopEdges" type="Node2D" parent="."]
+script = ExtResource( 10 )
 
 [node name="Static" type="StaticBody2D" parent="."]
 collision_layer = 8388609

--- a/classes/solid/terrain/terrain_polygon.tscn
+++ b/classes/solid/terrain/terrain_polygon.tscn
@@ -27,15 +27,11 @@ texture_spritesheet = ExtResource( 3 )
 [node name="Body" type="Polygon2D" parent="."]
 texture = SubResource( 2 )
 
-[node name="TopEdgeEndcaps" type="Node2D" parent="."]
-z_index = 2
-script = ExtResource( 10 )
-__meta__ = {
-"_editor_description_": ""
-}
-
-[node name="Borders" type="Node2D" parent="."]
+[node name="Decorations" type="Node2D" parent="."]
 script = ExtResource( 4 )
+
+[node name="TopEdges" type="Node2D" parent="."]
+script = ExtResource( 10 )
 
 [node name="Static" type="StaticBody2D" parent="."]
 collision_layer = 8388609

--- a/classes/solid/terrain/terrain_polygon.tscn
+++ b/classes/solid/terrain/terrain_polygon.tscn
@@ -27,10 +27,10 @@ texture_spritesheet = ExtResource( 3 )
 [node name="Body" type="Polygon2D" parent="."]
 texture = SubResource( 2 )
 
-[node name="Decorations" type="Node2D" parent="."]
+[node name="Borders" type="Node2D" parent="."]
 script = ExtResource( 4 )
 
-[node name="TopEdges" type="Node2D" parent="."]
+[node name="TopEdgeEndcaps" type="Node2D" parent="."]
 script = ExtResource( 10 )
 
 [node name="Static" type="StaticBody2D" parent="."]


### PR DESCRIPTION
# Description of changes
Modifies terrain system to support background terrain layers.

***NOTE:** This PR is branched from #181. New changes start on May 30th.*

To make background terrain, two features are required: disable-able collision, and changeable Z-order. Collision was dead simple to connect to a checkbox, so the bulk of the changes here went into Z-sorting.

See, the system was designed to render the top border, then bottom, then sides, and use Z-sorting to put them at the right depth relative to each other. The problem was, this meant a terrain object was on no less than three Z-layers (body, sides, top+bottom). If you wanted to put a terrain in the background, it had to move no fewer than 3 steps at a time in order to stay together--which seems both inconvenient and counterintuitive!

With that in mind, I redesigned the system so the draw steps could be reordered in code (surprisingly non-trivial!), then set it up to draw the different borders from back to front--sorting via draw order rather than Z-order. This means entire terrain objects now only take up one Z-layer, which means they can step backwards and forwards easily (and fit between other layers 😉).

# Issue(s)
N/A - wanted to get this workable so I know how to make my grass background look its best. 