### PR TITLE
Make LD load again by cutting new item icons

### DIFF
--- a/scenes/menus/level_designer/icons/enemy/cheep_cheep.tres
+++ b/scenes/menus/level_designer/icons/enemy/cheep_cheep.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=2]
+
+[ext_resource path="res://classes/entity/enemy/cheep_cheep/cheep_cheep.png" type="Texture" id=1]
+
+[resource]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 0, 20, 18 )

--- a/scenes/menus/level_designer/icons/pickup/coin_blue.tres
+++ b/scenes/menus/level_designer/icons/pickup/coin_blue.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=2]
+
+[ext_resource path="res://classes/pickup/coin/coins.png" type="Texture" id=1]
+
+[resource]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 32, 16, 16 )

--- a/scenes/menus/level_designer/icons/pickup/coin_red.tres
+++ b/scenes/menus/level_designer/icons/pickup/coin_red.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=2]
+
+[ext_resource path="res://classes/pickup/coin/coins.png" type="Texture" id=1]
+
+[resource]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 16, 16, 16 )

--- a/scenes/menus/level_designer/icons/pickup/coin_yellow.tres
+++ b/scenes/menus/level_designer/icons/pickup/coin_yellow.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=2]
+
+[ext_resource path="res://classes/pickup/coin/coins.png" type="Texture" id=1]
+
+[resource]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 0, 16, 16 )

--- a/scenes/menus/level_designer/icons/pickup/silver_shine.tres
+++ b/scenes/menus/level_designer/icons/pickup/silver_shine.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=2]
+
+[ext_resource path="res://gui/hud/hud_icons.png" type="Texture" id=1]
+
+[resource]
+atlas = ExtResource( 1 )
+region = Rect2( 67, 3, 16, 17 )

--- a/scenes/menus/level_designer/items.xml.tres
+++ b/scenes/menus/level_designer/items.xml.tres
@@ -69,24 +69,24 @@
 
     <item id="0" name="Yellow Coin" description="A single coin.">
 		<scene path="res://classes/pickup/coin/yellow/coin_yellow.tscn" />
-		<texture tag="Placed" path="res://classes/pickup/coin/yellow/coin0.png" />
+		<texture tag="Placed" path="res://scenes/menus/level_designer/icons/pickup/coin_yellow.tres" />
         <inherit name="ball" />
     </item>
 
     <item id="1" name="Red Coin" description="Counts for 2 yellow coins. Collect them all to summon a Shine Sprite!" />
 		<scene path="res://classes/pickup/coin/red/coin_red.tscn" />
-		<texture tag="Placed" path="res://classes/pickup/coin/red/red_coin0.png" />
+		<texture tag="Placed" path="res://scenes/menus/level_designer/icons/pickup/coin_red.tres" />
         <inherit name="ball" />
 	</item>
 
     <item id="2" name="Blue Coin" description="Counts for 5 yellow coins!">
 		<scene path="res://classes/pickup/coin/blue/coin_blue.tscn" />
-		<texture tag="Placed" path="res://classes/pickup/coin/blue/blue_coin0.png" />
+		<texture tag="Placed" path="res://scenes/menus/level_designer/icons/pickup/coin_blue.tres" />
         <inherit name="ball" />
     </item>
 
     <item id="3" name="Silver Shine" description="Collect them all to summon a Shine Sprite!">
-		<texture tag="List" path="res://gui/hud/hud_silver_shine.png" />
+		<texture tag="List" path="res://scenes/menus/level_designer/icons/pickup/silver_shine.tres" />
         <inherit name="ball" />
     </item>
 
@@ -183,8 +183,8 @@
 	
     <item id="17" name="Cheep Cheep" description="A fish. It will swim through water, and hop on land. When it sees a target, it will swim toward them and damage them by touching them. It can be attacked to kill it, dropping a coin.">
 		<scene path="res://classes/entity/enemy/cheep_cheep/cheep_cheep.tscn" />
-		<texture tag="List" path="res://classes/entity/enemy/cheep_cheep/cheep_cheep1.png" />
-		<texture tag="Placed" path="res://classes/entity/enemy/cheep_cheep/cheep_cheep1.png" />
+		<texture tag="List" path="res://scenes/menus/level_designer/icons/enemy/cheep_cheep.tres" />
+		<texture tag="Placed" path="res://scenes/menus/level_designer/icons/enemy/cheep_cheep.tres" />
         <inherit name="post" />
     </item>
 	

--- a/scenes/menus/level_designer/menu_control.gd
+++ b/scenes/menus/level_designer/menu_control.gd
@@ -18,6 +18,7 @@ func fill_grid():
 				path = level_editor.item_textures[item_id]["Placed"]
 			
 			var stream: StreamTexture = load(path)
+			assert(stream != null, "Failed to load LD item icon from path " + path)
 			tex.atlas = stream
 			var min_size = Vector2(
 				min(

--- a/scenes/menus/level_designer/menu_control.gd
+++ b/scenes/menus/level_designer/menu_control.gd
@@ -2,6 +2,8 @@ extends Control
 
 const LIST_ITEM = preload("./ldui/list_item.tscn")
 
+const MSG_ICON_LOAD_FAIL = "Failed to load LD item icon from path "
+
 onready var level_editor := $"/root/Main"
 onready var item_grid = $ItemPane/ItemBlock/ItemDisplay/Back/Base/ItemGrid
 onready var polygon_grid = $ItemPane/ItemBlock/ItemDisplay/Back/Base/PolygonGrid
@@ -11,29 +13,40 @@ func fill_grid():
 	for item_id in range(level_editor.item_textures.size()):
 		if level_editor.item_textures[item_id] != null:
 			var button = LIST_ITEM.instance()
-			var tex: AtlasTexture = AtlasTexture.new()
+			var tex: Texture
 			
+			# Find the path to this item's icon texture.
 			var path = level_editor.item_textures[item_id]["List"]
 			if path == null:
 				path = level_editor.item_textures[item_id]["Placed"]
 			
-			var stream: StreamTexture = load(path)
-			assert(stream != null, "Failed to load LD item icon from path " + path)
-			tex.atlas = stream
-			var min_size = Vector2(
-				min(
-					stream.get_width(),
-					32
-				),
-				min(
-					stream.get_height(),
-					32
+			if path.ends_with(".png") or path.ends_with(".gif"):
+				# Path is to an image file. Attempt opening it.
+				var stream: StreamTexture = load(path)
+				assert(stream != null, MSG_ICON_LOAD_FAIL + path)
+				
+				# Create an atlas texture around it.
+				tex = AtlasTexture.new()
+				tex.atlas = stream
+				var min_size = Vector2(
+					min(
+						stream.get_width(),
+						32
+					),
+					min(
+						stream.get_height(),
+						32
+					)
 				)
-			)
-			tex.region = Rect2(
-				stream.get_size() / 2 - min_size / 2,
-				min_size
-			)
+				tex.region = Rect2(
+					stream.get_size() / 2 - min_size / 2,
+					min_size
+				)
+			elif path.ends_with(".tres"):
+				# Path is to a texture resource. Open it directly,
+				tex = load(path) as Texture
+				assert(tex != null, MSG_ICON_LOAD_FAIL + path)
+			
 			button.rect_min_size = Vector2(32, 32)
 			button.get_node("Icon").texture = tex
 			button.item_id = item_id


### PR DESCRIPTION
# Description of changes
Apparently ever since the 0.1.6 graphics overhaul, opening the Level Designer has crashed the game (editor)/caused catastrophic breakage (web). This PR fixes that.

The problem was, the LD was using loose frames of animation as icons for the item menu. When the loose frames were replaced with atlases, the paths to the loose frames weren't updated--nor could they be, since the frames were now part of large atlases.

To fix this, I cut Atlas Textures (quicker to make than PNGs) of all the offending objects--coins in all colors, Cheep Cheeps, and Silver Shines (which currently use a HUD widget for their icon)--and updated the icon loader to support `.tres` Texture resources in addition to .png files. (Any Texture, not just Atlas Textures--seems silly to limit ourselves :P)

# Issue(s)
N/A - just hard to work on a broken LD ;)