### PR TITLE
Fix garbage reverb thoroughly

### DIFF
--- a/classes/global/singleton/singleton.gd
+++ b/classes/global/singleton/singleton.gd
@@ -288,7 +288,10 @@ func save_input_map(input_json):
 
 
 func reset_bus_effect(channel, effect_idx):
-	var bus_index = AudioServer.get_bus_index(channel)
-	var bus_effect = AudioServer.get_bus_effect(bus_index, effect_idx)
-	AudioServer.remove_bus_effect(bus_index, 0) # this just gets rid of any unwanted gunk stuck in the bus
-	AudioServer.add_bus_effect(bus_index, bus_effect, 0)
+	# If the passed channel is a String, convert it to a bus index.
+	if channel is String:
+		channel = AudioServer.get_bus_index(channel)
+	
+	var bus_effect = AudioServer.get_bus_effect(channel, effect_idx)
+	AudioServer.remove_bus_effect(channel, 0) # this just gets rid of any unwanted gunk stuck in the bus
+	AudioServer.add_bus_effect(channel, bus_effect, 0)

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -232,7 +232,7 @@ func _on_WaterCheck_area_entered(_area):
 	
 	# Reset reverb effect. This clears any reverb tail left in the buffer
 	# from last time in water (or from the title screen, when the bus is on).
-	Singleton.reset_bus_effect("~Water Verb:", 0)
+	Singleton.reset_bus_effect(Singleton.WATER_VRB_BUS, 0)
 
 
 func _on_WaterCheck_area_exited(_area):

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -181,8 +181,6 @@ func _ready():
 	
 	switch_state(S.NEUTRAL) # reset state to avoid short mario glitch
 	
-	Singleton.reset_bus_effect("~Water Verb:", 0) # prevents garbage reverb
-	
 	# If we came from another scene, load our data from that scene.
 	if Singleton.warp_location != null:
 		position = Singleton.warp_location
@@ -231,6 +229,10 @@ func _on_WaterCheck_area_entered(_area):
 	switch_state(S.NEUTRAL)
 	# Refill FLUDD
 	water = max(water, 100)
+	
+	# Reset reverb effect. This clears any reverb tail left in the buffer
+	# from last time in water (or from the title screen, when the bus is on).
+	Singleton.reset_bus_effect("~Water Verb:", 0)
 
 
 func _on_WaterCheck_area_exited(_area):


### PR DESCRIPTION
# Description of changes
I've caught #168 cropping up here and there still--it's a lot subtler, but on rare occasions, enough can happen immediately before jumping out of water that the leftover reverb tail is audible when it spills over into the next body of water (try superswimming out of water immediately after pounding into it).

To fix this, I moved the reverb reset from `_ready()` to `_on_WaterCheck_area_entered()`. This way, the reverb buffer is forcibly cleared every single time Mario hits water, meaning there's no possible way reverb from last time could spill over.

# Issue(s)
Closes some loose ends on #168. 