### PR TITLE
Fixed water splashes being huge

### DIFF
--- a/classes/water/water.gd
+++ b/classes/water/water.gd
@@ -310,7 +310,7 @@ func _handle_impact(body, is_exit):
 		var speed_mult = sqrt(3 * body_speed) / 2
 		# Factor in body's area
 		var player_area = 348 # Player character's default area is the baseline
-		var area_mult = 4 * (other_shape.size.x * other_shape.size.y / player_area)
+		var area_mult = (other_shape.size.x * other_shape.size.y / player_area)
 		height_mult *= area_mult
 		speed_mult *= area_mult
 		


### PR DESCRIPTION
# Description of changes
Fixes an issue with the waves being too big in 4.1
I tried finding a proper fix for this, but I can't see why it suddenly amplifies the effect.

This works however, and the scaling doesn't seem to be impacted is this should suffice.

# Issue(s)
Closes N/A