### PR TITLE
Fix all spots which give int division warnings

### DIFF
--- a/classes/entity/passive/goonie/goonie.gd
+++ b/classes/entity/passive/goonie/goonie.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
 	if not disabled:
 		sprite.play()
 	
-	# warning-ignore:integer_division
+	@warning_ignore("integer_division")
 	time_count = rng.randi_range(0, TIME_UP / 2)
 	vel.x = 2 + rng.randf() * 0.5
 	vel.y = -0.7 - rng.randf() * 0.25
@@ -75,7 +75,7 @@ func physics_step() -> void:
 			if time_count >= TIME_UP and sprite.frame == 2:
 				sprite.animation = "swoop"
 				
-				# warning-ignore:integer_division
+				@warning_ignore("integer_division")
 				time_count = rng.randi_range(0, TIME_DOWN/2)
 		else:
 			move_vec = Vector2(vel.x * 1.5 * 32/60 * flip_sign, 1.5*32/60)
@@ -83,7 +83,7 @@ func physics_step() -> void:
 			if time_count >= TIME_DOWN:
 				sprite.animation = "flap"
 				sprite.frame = 5
-				# warning-ignore:integer_division
+				@warning_ignore("integer_division")
 				time_count = rng.randi_range(0, TIME_UP/2)
 		time_count += 1
 	

--- a/classes/global/singleton/warp.gd
+++ b/classes/global/singleton/warp.gd
@@ -42,8 +42,8 @@ func warp(dir: Vector2, location: Vector2, path: String):
 	if direction.y == 0:
 		pos = (1 - direction.x) * window_size.x / 2
 		curve_top = Vector2(pos, 0)
-		curve_arc = Vector2(0, window.size.y / 2)
-		curve_bottom = Vector2(pos, window.size.y)
+		curve_arc = Vector2(0, window_size.y / 2)
+		curve_bottom = Vector2(pos, window_size.y)
 	else:
 		pos = (1 - direction.y) * window_size.y / 2
 		curve_top = Vector2(0, pos)

--- a/classes/global/singleton/warp.gd
+++ b/classes/global/singleton/warp.gd
@@ -10,16 +10,26 @@ var scene_path = ""
 var flip = false
 var anim_timer = 0
 
-@onready var curve_arc = Vector2(0, get_window().size.y / 2)
-@onready var curve_bottom = Vector2(0, get_window().size.y)
+@onready var window = get_window()
+@onready var curve_arc = Vector2(0, float(window.size.y) / 2)
+@onready var curve_bottom = Vector2(0, window.size.y)
 
 func _ready():
 	curve.add_point(Vector2(0, 0))
-	curve.add_point(Vector2(0, get_window().size.y))
-	polygon = PackedVector2Array([Vector2(0, 0), Vector2(0, get_window().size.y / 2), Vector2(0, get_window().size.y), Vector2(0, get_window().size.y), Vector2(0, 0)])
+	curve.add_point(Vector2(0, window.size.y))
+	polygon = PackedVector2Array([
+		Vector2(0, 0),
+		Vector2(0, float(window.size.y) / 2),
+		Vector2(0, window.size.y),
+		Vector2(0, window.size.y),
+		Vector2(0, 0)
+	])
 
 
 func warp(dir: Vector2, location: Vector2, path: String):
+	# Preconvert this to a float vector to avoid int-division errors.
+	var window_size = Vector2(window.size)
+	
 	var cam_area = $"/root/Main/CameraArea"
 	if cam_area != null:
 		cam_area.frozen = true
@@ -30,38 +40,41 @@ func warp(dir: Vector2, location: Vector2, path: String):
 	
 	var pos
 	if direction.y == 0:
-		pos = (1 - direction.x) * get_window().size.x / 2
+		pos = (1 - direction.x) * window_size.x / 2
 		curve_top = Vector2(pos, 0)
-		curve_arc = Vector2(0, get_window().size.y / 2)
-		curve_bottom = Vector2(pos, get_window().size.y)
+		curve_arc = Vector2(0, window.size.y / 2)
+		curve_bottom = Vector2(pos, window.size.y)
 	else:
-		pos = (1 - direction.y) * get_window().size.y / 2
+		pos = (1 - direction.y) * window_size.y / 2
 		curve_top = Vector2(0, pos)
-		curve_arc = Vector2(get_window().size.x / 2, 0)
-		curve_bottom = Vector2(get_window().size.x, pos)
+		curve_arc = Vector2(window_size.x / 2, 0)
+		curve_bottom = Vector2(window_size.x, pos)
 
 
 func _physics_process(_delta):
 	if enter != 0:
 		anim_timer += 1
 	if (enter == 1 and anim_timer >= 44):
+		# Preconvert this to a float vector to avoid int-division errors.
+		var window_size = Vector2(window.size)
+		
 		anim_timer = 0
 		
 		curve.clear_points()
 		curve.add_point(Vector2(0, 0))
 		var pos
 		if direction.x == 0:
-			curve.add_point(Vector2(0, get_window().size.y))
-			pos = (1 - direction.y) * get_window().size.y / 2
+			curve.add_point(Vector2(0, window_size.y))
+			pos = (1 - direction.y) * window_size.y / 2
 			curve_top = Vector2(0, pos)
-			curve_arc = Vector2(get_window().size.x / 2, 0)
-			curve_bottom = Vector2(get_window().size.x, pos)
+			curve_arc = Vector2(window_size.x / 2, 0)
+			curve_bottom = Vector2(window_size.x, pos)
 		else:
-			curve.add_point(Vector2(get_window().size.x, 0))
-			pos = (1 - direction.x) * get_window().size.x / 2
+			curve.add_point(Vector2(window_size.x, 0))
+			pos = (1 - direction.x) * window_size.x / 2
 			curve_top = Vector2(pos, 0)
-			curve_arc = Vector2(0, get_window().size.y / 2)
-			curve_bottom = Vector2(pos, get_window().size.y)
+			curve_arc = Vector2(0, window_size.y / 2)
+			curve_bottom = Vector2(pos, window_size.y)
 		
 		Singleton.warp_to(scene_path, $"/root/Main/Player")
 		
@@ -75,12 +88,15 @@ func _physics_process(_delta):
 func _process(delta):
 	var dmod = min(60 * delta, 1)
 	if enter != 0:
+		# Preconvert this to a float vector to avoid int-division errors.
+		var window_size = Vector2(window.size)
+		
 		visible = true
 		var speed
 		if direction.x == 0:
-			speed = get_window().size.y / Singleton.DEFAULT_SIZE.y
+			speed = window_size.y / Singleton.DEFAULT_SIZE.y
 		else:
-			speed = get_window().size.x / Singleton.DEFAULT_SIZE.x
+			speed = window_size.x / Singleton.DEFAULT_SIZE.x
 		curve_top += 20 * direction * speed * dmod
 		curve_arc -= 5 * direction * enter * speed * dmod
 		curve_bottom += 20 * direction * speed * dmod
@@ -89,11 +105,11 @@ func _process(delta):
 		curve.set_point_position(1, curve_bottom)
 		if direction.x == 0:
 			if direction.y * enter == -1:
-				polygon = PackedVector2Array([Vector2(0, get_window().size.y)] + Array(curve.get_baked_points()) + [Vector2(get_window().size.x, get_window().size.y)])
+				polygon = PackedVector2Array([Vector2(0, window_size.y)] + Array(curve.get_baked_points()) + [Vector2(window_size.x, window_size.y)])
 			else:
-				polygon = PackedVector2Array([Vector2(0, 0)] + Array(curve.get_baked_points()) + [Vector2(get_window().size.x, 0)])
+				polygon = PackedVector2Array([Vector2(0, 0)] + Array(curve.get_baked_points()) + [Vector2(window_size.x, 0)])
 		else:
 			if direction.x * enter == -1:
-				polygon = PackedVector2Array([Vector2(get_window().size.x, 0)] + Array(curve.get_baked_points()) + [Vector2(get_window().size.x, get_window().size.y)])
+				polygon = PackedVector2Array([Vector2(window_size.x, 0)] + Array(curve.get_baked_points()) + [Vector2(window_size.x, window_size.y)])
 			else:
-				polygon = PackedVector2Array([Vector2(0, 0)] + Array(curve.get_baked_points()) + [Vector2(0, get_window().size.y)])
+				polygon = PackedVector2Array([Vector2(0, 0)] + Array(curve.get_baked_points()) + [Vector2(0, window_size.y)])

--- a/classes/global/touch_control/touch_button.gd
+++ b/classes/global/touch_control/touch_button.gd
@@ -27,7 +27,7 @@ func _setup_textures(new_id: String):
 	var index = ID_LIST.find(new_id)
 	var pos = Vector2.ZERO
 	# Get the column of the button
-	pos.x = floor(index / TEXTURE_COLUMN_SIZE)
+	pos.x = floor(float(index) / TEXTURE_COLUMN_SIZE)
 	# Get the row
 	pos.y = index % TEXTURE_COLUMN_SIZE
 	# Multiply x coord by 2, because there are two buttons per cell

--- a/classes/global/touch_control/touch_controls.gd
+++ b/classes/global/touch_control/touch_controls.gd
@@ -38,19 +38,22 @@ func _get_button_scale() -> int:
 	# Divide *that* by the value we found earlier, and floor it. Do that for both X and Y.
 	# Take the smaller value of those two. We will use this as the default scale multiplier.
 	
+	var window_size = Vector2(get_window().size)
 	var output = min(
 		floor(
-			(get_window().size.x / 2) / (BUTTON_DIMENSIONS.x * 6 * scale.x)
+			(window_size.x / 2) / (BUTTON_DIMENSIONS.x * 6 * scale.x)
 		),
 		floor(
-			(get_window().size.y / 2) / (BUTTON_DIMENSIONS.y * 4 * scale.y)
+			(window_size.y / 2) / (BUTTON_DIMENSIONS.y * 4 * scale.y)
 		)
 	)
 	return output
 
 
 func _process(_delta) -> void:
-	var gui_scale = max(floor(get_window().size.x / Singleton.DEFAULT_SIZE.x), 1)	
+	var gui_scale = max(
+		floor( float(get_window().size.x) / Singleton.DEFAULT_SIZE.x),
+		1)
 	visible = Singleton.touch_control
 	for anchor in anchors:
 		anchor.scale = Vector2.ONE * gui_scale * button_scale

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -2,6 +2,7 @@ extends AnimatedSprite2D
 
 const NO_ANIM_CHANGE = ""
 
+@warning_ignore("integer_division")
 const TRIPLE_FLIP_HALFWAY = PlayerCharacter.TRIPLE_FLIP_TIME / 2
 
 const SLOW_SPIN_START_SPEED = 1

--- a/classes/solid/telescoping/tipping_log/tipping_log.gd
+++ b/classes/solid/telescoping/tipping_log/tipping_log.gd
@@ -12,7 +12,7 @@ var ang_vel = 0.0
 
 func set_width(val):
 	super.set_width(val)
-	# warning-ignore:integer_division
+	@warning_ignore("integer_division")
 	$Rod/RideArea/RideShape.shape.size.x = middle_segment_width * val + end_segment_width
 
 

--- a/classes/water/water.gd
+++ b/classes/water/water.gd
@@ -118,7 +118,7 @@ func _process(dt):
 
 	# Apply default "still water" ripple.
 	var x_os_size = get_window().size.x
-	var x_camera_edge = camera.global_position.x - x_os_size / 2
+	var x_camera_edge = camera.global_position.x - float(x_os_size) / 2
 	for key in surface.keys():
 		var global_x = surface[key].x + top_left_corner.x
 		if global_x >= x_camera_edge + x_os_size:

--- a/gui/hud/shine_map.gd
+++ b/gui/hud/shine_map.gd
@@ -22,4 +22,5 @@ func _process(_delta):
 
 func refresh_scroll():
 	if max_height != 0:
-		scroll.offset_top = 1-(courses.offset_top / max_height) * (get_window().size.y / gui_scale - 54 - 51)
+		scroll.offset_top = 1-(courses.offset_top / max_height) \
+			* (float(get_window().size.y) / gui_scale - 54 - 51)

--- a/gui/pause/map_course.gd
+++ b/gui/pause/map_course.gd
@@ -6,11 +6,13 @@ extends Control
 
 
 func resize():
+	var window_size = Vector2(get_window().size) # convert to float vector - avoids int div warning
+	
 	# protect against division-by-zero error i ran into on win7
 	# caused by minimizing the window using the button in the right edge of the taskbar
-	if get_window().size.y == 0: return
+	if window_size.y == 0: return
 	
-	if get_window().size.x / get_window().size.y > 1.474:
+	if window_size.x / window_size.y > 1.474:
 		coin_group.columns = 6
 		coin_group.offset_top = 90
 		hover.offset = Vector2(-20, 10)

--- a/gui/pause/unpause.gd
+++ b/gui/pause/unpause.gd
@@ -7,7 +7,7 @@ func _init():
 
 
 func _ready():
-	scale = Vector2.ONE * max(floor(get_window().size.x / Singleton.DEFAULT_SIZE.x), 1) * 2
+	scale = Vector2.ONE * max(floor(float(get_window().size.x) / Singleton.DEFAULT_SIZE.x), 1) * 2
 
 
 func _process(_delta):

--- a/scenes/levels/tutorial_1/bg/clouds_lower.gd
+++ b/scenes/levels/tutorial_1/bg/clouds_lower.gd
@@ -3,4 +3,4 @@ extends TextureRect
 
 func _process(_delta):
 	scale = Vector2.ONE * Singleton.get_screen_scale(1)
-	pivot_offset.y = 93 / 2
+	pivot_offset.y = 93.0 / 2

--- a/scenes/menus/title/logo/logo.gd
+++ b/scenes/menus/title/logo/logo.gd
@@ -8,9 +8,10 @@ var wait = 0.0
 
 func _process(delta):
 	var dmod = 60 * delta
+	var window_size = Vector2(get_window().size) # convert to float vector - avoids int div warning
 	scale = get_parent().scale_vec
-	position.x = round(get_window().size.x / 2)
-	position.y = -(104 * scale.y) + ease_out_quart(min(progress, 60) / 60) * ((104 * scale.y) + round(get_window().size.y / 8 * 3))
+	position.x = round(window_size.x / 2)
+	position.y = -(104 * scale.y) + ease_out_quart(min(progress, 60) / 60) * ((104 * scale.y) + round(window_size.y / 8 * 3))
 	if wait < 30:
 		wait += dmod
 	else:

--- a/scenes/menus/title/start_text.gd
+++ b/scenes/menus/title/start_text.gd
@@ -12,9 +12,10 @@ func _init():
 func _process(delta):
 	var dmod = 60 * delta
 	var scale = get_parent().scale_vec
+	var window_size = Vector2(get_window().size) # convert to float vector - avoids int div warning
 	scale = scale * 2 * Vector2.ONE
-	pivot_offset.x = get_window().size.x / 2
-	offset_top = get_window().size.y / 4 * 3
+	pivot_offset.x = window_size.x / 2
+	offset_top = window_size.y / 4 * 3
 	if wait < 150:
 		wait += dmod
 	else:

--- a/scenes/menus/title/title.gd
+++ b/scenes/menus/title/title.gd
@@ -14,11 +14,12 @@ var dampen = false
 var scale_vec
 func _process(delta):
 	var dmod = 60 * delta
+	var window_size = Vector2(get_window().size) # convert to float vector - avoids int div warning
 	scale_vec = Vector2.ONE * max(
 		1,
 		min(
-			round(get_window().size.x / Singleton.DEFAULT_SIZE.x),
-			round(get_window().size.y / Singleton.DEFAULT_SIZE.y)
+			round(window_size.x / Singleton.DEFAULT_SIZE.x),
+			round(window_size.y / Singleton.DEFAULT_SIZE.y)
 		)
 	)
 	if Input.is_action_just_pressed("interact") and !menu.visible:

--- a/scenes/menus/title/title_bg/mushmoon.gd
+++ b/scenes/menus/title/title_bg/mushmoon.gd
@@ -7,10 +7,11 @@ var season_progress = 0
 func _process(delta):
 	var dmod = 60 * delta
 	var scalar = get_parent().scale_vec
+	var window_size = Vector2(get_window().size) # convert to float vector - avoids int div warning
 	scale = scalar * Vector2.ONE
 	progress += (1.0 / 60.0) / 10 * dmod
 	if progress >= 1.5:
 		season_progress = (season_progress + 1) % 9
 		progress = 0
-	position.y = get_window().size.y * (1 - progress)
-	position.x = get_window().size.x / 10 * -progress + get_window().size.x / 10 * (8 - season_progress)
+	position.y = window_size.y * (1 - progress)
+	position.x = window_size.x / 10 * -progress + window_size.x / 10 * (8 - season_progress)


### PR DESCRIPTION
# Description of changes
Fix all remaining spots which give int-division warnings.

Spots commented with `# warning-ignore:integer_division` were upgraded to use the proper Godot 4 version of that command (`@warning_ignore("integer_division")`).

I'm assuming other erroring divisions were expected to divide as float, so any such spots have been upgraded with the required casts to make that happen.

A lot of these warnings came from spots that were using `get_window().size`. Many of them called this function multiple times per function, or even per line, and that seems a bit stinky...so I rewrote them to call once, convert to a float vector, then reuse the converted vector. Also saves horizontal real estate in the scripts.