### PR TITLE
Fix editor errors caused by toolscripts

### DIFF
--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -7,7 +7,7 @@ extends Interactable
 @export var can_pivot: bool = false
 @export var back_sprite: bool = false
 
-@onready var dialog = $"/root/Main/Player/Camera/HUD/HUDControl/DialogBox"
+@onready var dialog = $"/root/Main/Player/Camera/HUD/HUDControl/DialogBox" if !Engine.is_editor_hint() else null
 
 
 func _interact_with(body):

--- a/classes/zone/camera_area/camera_area.gd
+++ b/classes/zone/camera_area/camera_area.gd
@@ -1,4 +1,3 @@
-@tool
 extends Polygon2D
 
 #@export var spawn_position: Vector2 setget force_draw
@@ -20,8 +19,6 @@ var frozen = false
 
 
 func _ready():
-	if Engine.is_editor_hint():
-		return
 	# Invert the current polygon
 	set_physics_polygon(polygon)
 	
@@ -35,9 +32,6 @@ func _ready():
 
 
 func _physics_process(dt):
-	if Engine.is_editor_hint():
-		return
-
 	shrink_number = min(1, shrink_number + dt * 5)
 	var target_size = Vector2(get_window().size) / camera.zoom * shrink_number
 	if target_size.length() != window_prev_length:

--- a/classes/zone/trigger/warpzone/warp_zone.gd
+++ b/classes/zone/trigger/warpzone/warp_zone.gd
@@ -6,8 +6,6 @@ extends Area2D
 @export var scene_path: String
 @export var size: Vector2: set = set_size
 
-@onready var player = $"/root/Main/Player"
-
 
 func set_size(new_size):
 	$CollisionShape2D.shape.size = new_size

--- a/classes/zone/trigger/warpzone/warp_zone.gd
+++ b/classes/zone/trigger/warpzone/warp_zone.gd
@@ -1,12 +1,13 @@
 @tool
 extends Area2D
 
-@onready var sweep_effect: Warp = $"/root/Singleton/Warp"
-@onready var player = $"/root/Main/Player"
 @export var sweep_direction: Vector2
 @export var spawn_location: Vector2
 @export var scene_path: String
 @export var size: Vector2: set = set_size
+
+@onready var sweep_effect: Warp = $"/root/Singleton/Warp"
+@onready var player = $"/root/Main/Player"
 
 
 func set_size(new_size):

--- a/classes/zone/trigger/warpzone/warp_zone.gd
+++ b/classes/zone/trigger/warpzone/warp_zone.gd
@@ -6,7 +6,6 @@ extends Area2D
 @export var scene_path: String
 @export var size: Vector2: set = set_size
 
-@onready var sweep_effect: Warp = $"/root/Singleton/Warp"
 @onready var player = $"/root/Main/Player"
 
 
@@ -16,5 +15,7 @@ func set_size(new_size):
 
 
 func _on_WarpZone_body_entered(_body):
+	var sweep_effect: Warp = $"/root/Singleton/Warp"
+	# Change scenes ONLY if we're not already mid-scene-change!
 	if sweep_effect.enter != 1:
 		sweep_effect.warp(sweep_direction, spawn_location, scene_path)


### PR DESCRIPTION
# Description of changes
In the editor, a number of toolscripts throw errors on scene load, due to trying to `@onready` get nodes that don't exist yet. This PR fixes that using null checks, later initialization, and in `camera_area`'s case, just un-toolscripting things that don't need it.

# Issue(s)
N/A