### PR TITLE
Fix life hud flashing

### DIFF
--- a/gui/life_meter/life_meter.tscn
+++ b/gui/life_meter/life_meter.tscn
@@ -255,7 +255,6 @@ sprite_frames = SubResource("2")
 [node name="CoinMeter" type="AnimatedSprite2D" parent="MeterBase/Filler"]
 sprite_frames = SubResource("47")
 animation = &"charge"
-autoplay = "flash"
 script = ExtResource("7")
 
 [node name="CoinRing" type="Sprite2D" parent="MeterBase/Filler/CoinMeter"]


### PR DESCRIPTION
# Description of changes
<!-- Add in your changes and the importance of everything here -->
Very simple fix that prevents the life hud's coin meter from flashing when changing scenes.