### PR TITLE
Fix enemy hitbox priorities

### DIFF
--- a/classes/entity/enemy/entity_enemy.gd
+++ b/classes/entity/enemy/entity_enemy.gd
@@ -135,8 +135,9 @@ func _connect_signals():
 	super._connect_signals()
 	_connect_node_signal_if_exists(hurtbox_stomp, "area_entered", self, "_on_HurtboxStomp_area_entered")
 	_connect_node_signal_if_exists(hurtbox_strike, "body_entered", self, "_on_HurtboxStrike_body_entered")
-	_connect_node_signal_if_exists(hitbox, "body_entered", self, "_on_Hitbox_body_entered")
-	_connect_node_signal_if_exists(hitbox, "body_exited", self, "_on_Hitbox_body_exited")
+	# Connect enemy hitboxes in deferred mode to give them lower priority
+	_connect_node_signal_if_exists(hitbox, "body_entered", self, "_on_Hitbox_body_entered", true)
+	_connect_node_signal_if_exists(hitbox, "body_exited", self, "_on_Hitbox_body_exited", true)
 
 
 func set_disabled(val):

--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -22,13 +22,15 @@ const color_presets = [
 
 @export var disabled = false: set = set_disabled
 @export var mirror = false
-@export var color = 0: set = set_color
+@export var color: Koopa.ShellColor = Koopa.ShellColor.GREEN: set = set_color
 
 
 func set_color(new_color):
 	for i in range(3):
 		material.set_shader_parameter("color" + str(i), color_presets[new_color][i])
 	color = new_color
+	koopa.color = color
+	shell.color = color
 
 
 func _ready():
@@ -50,27 +52,21 @@ func _exit_tree():
 func _on_TopCollision_body_entered(body):
 	if body.is_spinning():
 		spawn_shell(body)
-	else:
-		if body.vel.y > -2:
-			$Kick.play()
-			koopa.position = Vector2(position.x, body.position.y + 33)
-			koopa.vel.y = body.vel.y
-			koopa.mirror = flip_h
-			koopa.color = color
-			body.vel.y = -5.5
-			body.vel.x *= 1.2
-			get_parent().call_deferred("add_child", koopa)
-			$TopCollision.set_deferred("monitoring", false)
-			$Damage.set_deferred("monitoring", false)
-			set_deferred("visible", false)
-			visible = false
-
-
-func _on_Kick_finished():
-	queue_free()
+	elif body.vel.y > -2:
+		change_state()
+		get_parent().call_deferred("add_child", koopa)
+		koopa.position = Vector2(position.x, body.position.y + 33)
+		koopa.vel.y = body.vel.y
+		koopa.mirror = flip_h
+		body.vel.y = -5
+		body.vel.x *= 1.2
 
 
 func _on_Damage_body_entered(body):
+	# Parakoopa was already defeated, return early
+	if !visible:
+		return
+	
 	if !body.is_diving(true):
 		if body.is_spinning():
 			spawn_shell(body)
@@ -82,26 +78,26 @@ func _on_Damage_body_entered(body):
 
 
 func spawn_shell(body):
-	$Kick.play()
+	change_state()
 	body.vel.y = -5
 	get_parent().call_deferred("add_child", shell)
 	shell.position = position + Vector2(0, 7.5)
-	shell.color = color
 	if body.global_position.x < global_position.x:
 		shell.vel.x = 5
 	else:
 		shell.vel.x = -5
-	$TopCollision.set_deferred("monitoring", false)
-	$Damage.set_deferred("monitoring", false)
-	set_deferred("visible", false)
+
+
+# Called whenever the parakoopa loses its wings
+func change_state():
+	$Kick.play()
+	top_collision.set_deferred("monitoring", false)
+	hurtbox.set_deferred("monitoring", false)
+	visible = false
 
 
 func set_disabled(val):
 	disabled = val
-	if hurtbox == null:
-		hurtbox = $Damage
-	if top_collision == null:
-		top_collision = $TopCollision
 	hurtbox.monitoring = !val
 	top_collision.monitoring = !val
 	if !Engine.is_editor_hint():

--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -53,7 +53,7 @@ func _on_TopCollision_body_entered(body):
 	if body.is_spinning():
 		spawn_shell(body)
 	elif body.vel.y > -2:
-		change_state()
+		defeat()
 		get_parent().call_deferred("add_child", koopa)
 		koopa.position = Vector2(position.x, body.position.y + 33)
 		koopa.vel.y = body.vel.y
@@ -78,7 +78,7 @@ func _on_Damage_body_entered(body):
 
 
 func spawn_shell(body):
-	change_state()
+	defeat()
 	body.vel.y = -5
 	get_parent().call_deferred("add_child", shell)
 	shell.position = position + Vector2(0, 7.5)
@@ -88,8 +88,8 @@ func spawn_shell(body):
 		shell.vel.x = -5
 
 
-# Called whenever the parakoopa loses its wings
-func change_state():
+# Called when the parakoopa loses its wings
+func defeat():
 	$Kick.play()
 	top_collision.set_deferred("monitoring", false)
 	hurtbox.set_deferred("monitoring", false)

--- a/classes/entity/enemy/koopa/parakoopa.tscn
+++ b/classes/entity/enemy/koopa/parakoopa.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=15 format=3 uid="uid://b6jp4ecuo2iwc"]
 
 [ext_resource type="Texture2D" uid="uid://c56k3dswoefph" path="res://classes/entity/enemy/koopa/parakoopa.png" id="1"]
-[ext_resource type="Material" path="res://shaders/palette.tres" id="2"]
+[ext_resource type="Material" uid="uid://doskvnt6b4sl2" path="res://shaders/palette.tres" id="2"]
 [ext_resource type="Script" path="res://classes/entity/enemy/koopa/parakoopa.gd" id="8"]
 [ext_resource type="AudioStream" uid="uid://bgidqcur663qn" path="res://classes/entity/enemy/koopa/shell_kick.ogg" id="9"]
 
@@ -102,4 +102,4 @@ monitorable = false
 shape = SubResource("10")
 
 [connection signal="body_entered" from="TopCollision" to="." method="_on_TopCollision_body_entered"]
-[connection signal="body_entered" from="Damage" to="." method="_on_Damage_body_entered"]
+[connection signal="body_entered" from="Damage" to="." method="_on_Damage_body_entered" flags=3]

--- a/classes/entity/entity.gd
+++ b/classes/entity/entity.gd
@@ -122,6 +122,6 @@ func _set_node_property_if_exists(node: Node, property: String, val) -> void:
 
 
 # Connect a node to a signal if the node exists.
-func _connect_node_signal_if_exists(node, signame: String, target, method: String) -> void:
+func _connect_node_signal_if_exists(node, signame: String, target, method: String, deferred : bool = false) -> void:
 	if node != null:
-		node.connect(signame, Callable(target, method))
+		node.connect(signame, Callable(target, method), CONNECT_DEFERRED if deferred else 0)


### PR DESCRIPTION
# Description of changes
<!-- Add in your changes and the importance of everything here -->
Actual changes:
- Enemy entities use a new "deferred" connect mode to ensure their signals are always processed after the player.
- While fixing the parakoopa's hitboxes, I also refactored its script a bit.

Some extra things to note:
- While spinning enemies is more consistent, the timing feels way too generous now. Will open a proposal to fix this later.
- The transitions between parakoopas, koopas and shells are still super jank. Will open a proposal to clean them up later.

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #128
Fixes the first reproduction scenario of #118 