### PR TITLE
Fix main menu texture repeats

### DIFF
--- a/scenes/menus/title/main_menu/main_menu.tscn
+++ b/scenes/menus/title/main_menu/main_menu.tscn
@@ -222,6 +222,7 @@ animations = [{
 }]
 
 [node name="Menu" type="Control"]
+texture_repeat = 2
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/scenes/menus/title/main_menu/main_menu.tscn
+++ b/scenes/menus/title/main_menu/main_menu.tscn
@@ -247,7 +247,7 @@ texture = ExtResource("9")
 position = Vector2(320, 124)
 texture = SubResource("1")
 
-[node name="Polygon2D" type="Polygon2D" parent="Story"]
+[node name="Sheen" type="Polygon2D" parent="Story"]
 texture = ExtResource("16")
 polygon = PackedVector2Array(-66, 32, 66, 32, 66, 28, -66, 28)
 script = ExtResource("12")
@@ -289,7 +289,7 @@ texture = ExtResource("9")
 position = Vector2(4, 188)
 texture = SubResource("4")
 
-[node name="Polygon2D" type="Polygon2D" parent="Settings"]
+[node name="Sheen" type="Polygon2D" parent="Settings"]
 use_parent_material = true
 texture = ExtResource("16")
 polygon = PackedVector2Array(-66, 32, 66, 32, 66, 28, -66, 28)
@@ -335,7 +335,7 @@ texture = ExtResource("9")
 position = Vector2(320, 600)
 texture = SubResource("3")
 
-[node name="Polygon2D" type="Polygon2D" parent="Extras"]
+[node name="Sheen" type="Polygon2D" parent="Extras"]
 use_parent_material = true
 texture = ExtResource("16")
 polygon = PackedVector2Array(-66, 32, 66, 32, 66, 28, -66, 28)
@@ -381,7 +381,7 @@ texture = ExtResource("9")
 position = Vector2(636, 188)
 texture = SubResource("2")
 
-[node name="Polygon2D" type="Polygon2D" parent="LevelDesigner"]
+[node name="Sheen" type="Polygon2D" parent="LevelDesigner"]
 use_parent_material = true
 texture = ExtResource("16")
 polygon = PackedVector2Array(-66, 32, 66, 32, 66, 28, -66, 28)
@@ -493,7 +493,7 @@ joint_mode = 2
 begin_cap_mode = 2
 end_cap_mode = 2
 
-[node name="Polygon2D" type="Polygon2D" parent="."]
+[node name="Sheen" type="Polygon2D" parent="."]
 visible = false
 texture = ExtResource("16")
 polygon = PackedVector2Array(0, 0, 0, 304, 448, 304, 448, 0)


### PR DESCRIPTION
# Description of changes
Makes all textures inside the main menu repeat by default. This fixes the diagonal shines on the buttons, as well as the tiling on the apparently unused Line2D called "Stripe."

While I'm at it, also renames the diagonal shines to match their script name (which is "sheen," not "shine"--much clearer in a game about shines).

# Issue(s)
Closes #225, both parts of it.