### PR TITLE
Make pipes usable again

### DIFF
--- a/classes/interactable/pipe/pipe.tscn
+++ b/classes/interactable/pipe/pipe.tscn
@@ -11,7 +11,7 @@ size = Vector2(8.73426, 16)
 size = Vector2(32, 32)
 
 [node name="Pipe" type="Area2D"]
-collision_mask = 0
+collision_mask = 2
 monitorable = false
 script = ExtResource("3")
 sprite = NodePath("Sprite2D")


### PR DESCRIPTION
# Description of changes
Somewhere along the line, pipes were set to no longer monitor the player's layer. This PR simply fixes that, allowing pipes to work again.

# Issue(s)
N/A