### PR TITLE
Fix tiny FLUDD spray

### DIFF
--- a/classes/player/camera.gd
+++ b/classes/player/camera.gd
@@ -2,9 +2,9 @@ extends Camera2D
 
 const ZOOM_TIME = 0.5
 
-var current_zoom: float = 1.5
-var prev_zoom: float = 1.5
-var target_zoom: float = 1.5
+var current_zoom: float = 1
+var prev_zoom: float = 1
+var target_zoom: float = 1
 var zoom_timer: float = 0
 var rezooming: bool = false
 var target_limit_left = -10000000

--- a/classes/player/camera.gd
+++ b/classes/player/camera.gd
@@ -2,9 +2,9 @@ extends Camera2D
 
 const ZOOM_TIME = 0.5
 
-var current_zoom: float = 1
-var prev_zoom: float = 1
-var target_zoom: float = 1
+var current_zoom: float = 1.5
+var prev_zoom: float = 1.5
+var target_zoom: float = 1.5
 var zoom_timer: float = 0
 var rezooming: bool = false
 var target_limit_left = -10000000

--- a/classes/player/player.tscn
+++ b/classes/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=158 format=3 uid="uid://bujgheqb6pmrc"]
+[gd_scene load_steps=156 format=3 uid="uid://bujgheqb6pmrc"]
 
 [ext_resource type="Script" path="res://classes/dejitter_group/dejitter_group.gd" id="1"]
 [ext_resource type="Script" path="res://classes/player/fludd_spray_renderer.gd" id="2"]
@@ -1141,26 +1141,26 @@ size = Vector2(12, 2)
 [sub_resource type="RectangleShape2D" id="6"]
 size = Vector2(12, 2)
 
-[sub_resource type="Gradient" id="53"]
-colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
-
-[sub_resource type="GradientTexture2D" id="54"]
-gradient = SubResource("53")
-
 [sub_resource type="Curve" id="55"]
-_data = [Vector2(0, 0.495454), 0.0, 1.77478, 0, 0, Vector2(0.5, 1), 0.494444, 0.0, 0, 0]
+_data = [Vector2(0.5, 1), 0.494444, 0.0, 0, 0, Vector2(1, 0.5), 0.0, 1.77478, 0, 0]
 point_count = 2
+metadata/_snap_enabled = true
 
 [sub_resource type="CurveTexture" id="56"]
 width = 64
 curve = SubResource("55")
 
 [sub_resource type="ParticleProcessMaterial" id="44"]
+particle_flag_align_y = true
+particle_flag_disable_z = true
 direction = Vector3(0, 1, 0)
 spread = 10.0
 gravity = Vector3(0, 450, 0)
+orbit_velocity_min = 0.0
+orbit_velocity_max = 0.0
+scale_min = 0.75
+scale_max = 1.25
 scale_curve = SubResource("56")
-color_ramp = SubResource("54")
 anim_offset_max = 1.0
 
 [sub_resource type="AtlasTexture" id="48"]

--- a/classes/player/player.tscn
+++ b/classes/player/player.tscn
@@ -1148,7 +1148,7 @@ colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
 gradient = SubResource("Gradient_wg03u")
 
 [sub_resource type="Curve" id="Curve_7gnak"]
-_data = [Vector2(0, 0.495454), 0.0, 1.77478, 0, 0, Vector2(0.5, 1), 0.494444, 0.0, 0, 0]
+_data = [Vector2(0, 0.5), 0.0, 1.75, 0, 0, Vector2(0.5, 1), 0.5, 0.0, 0, 0]
 point_count = 2
 metadata/_snap_enabled = true
 
@@ -1160,10 +1160,10 @@ curve = SubResource("Curve_7gnak")
 particle_flag_align_y = true
 particle_flag_disable_z = true
 direction = Vector3(0, 1, 0)
-spread = 5.0
-gravity = Vector3(0, 450, 0)
-initial_velocity_min = 200.0
-initial_velocity_max = 300.0
+spread = 7.5
+gravity = Vector3(0, 675, 0)
+initial_velocity_min = 300.0
+initial_velocity_max = 450.0
 orbit_velocity_min = 0.0
 orbit_velocity_max = 0.0
 scale_min = 1.25
@@ -1309,7 +1309,7 @@ position = Vector2(0, 10)
 shape = SubResource("6")
 
 [node name="SprayViewport" type="SubViewport" parent="."]
-size = Vector2i(640, 360)
+size = Vector2i(640, 180)
 render_target_update_mode = 3
 
 [node name="SprayParticles" type="GPUParticles2D" parent="SprayViewport"]

--- a/classes/player/player.tscn
+++ b/classes/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=156 format=3 uid="uid://bujgheqb6pmrc"]
+[gd_scene load_steps=158 format=3 uid="uid://bujgheqb6pmrc"]
 
 [ext_resource type="Script" path="res://classes/dejitter_group/dejitter_group.gd" id="1"]
 [ext_resource type="Script" path="res://classes/player/fludd_spray_renderer.gd" id="2"]
@@ -1141,26 +1141,35 @@ size = Vector2(12, 2)
 [sub_resource type="RectangleShape2D" id="6"]
 size = Vector2(12, 2)
 
-[sub_resource type="Curve" id="55"]
-_data = [Vector2(0.5, 1), 0.494444, 0.0, 0, 0, Vector2(1, 0.5), 0.0, 1.77478, 0, 0]
+[sub_resource type="Gradient" id="Gradient_wg03u"]
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_aq6cg"]
+gradient = SubResource("Gradient_wg03u")
+
+[sub_resource type="Curve" id="Curve_7gnak"]
+_data = [Vector2(0, 0.495454), 0.0, 1.77478, 0, 0, Vector2(0.5, 1), 0.494444, 0.0, 0, 0]
 point_count = 2
 metadata/_snap_enabled = true
 
 [sub_resource type="CurveTexture" id="56"]
 width = 64
-curve = SubResource("55")
+curve = SubResource("Curve_7gnak")
 
 [sub_resource type="ParticleProcessMaterial" id="44"]
 particle_flag_align_y = true
 particle_flag_disable_z = true
 direction = Vector3(0, 1, 0)
-spread = 10.0
+spread = 5.0
 gravity = Vector3(0, 450, 0)
+initial_velocity_min = 200.0
+initial_velocity_max = 300.0
 orbit_velocity_min = 0.0
 orbit_velocity_max = 0.0
-scale_min = 0.75
-scale_max = 1.25
+scale_min = 1.25
+scale_max = 1.5
 scale_curve = SubResource("56")
+color_ramp = SubResource("GradientTexture1D_aq6cg")
 anim_offset_max = 1.0
 
 [sub_resource type="AtlasTexture" id="48"]
@@ -1305,11 +1314,11 @@ render_target_update_mode = 3
 
 [node name="SprayParticles" type="GPUParticles2D" parent="SprayViewport"]
 material = ExtResource("9")
-emitting = false
 amount = 50
 process_material = SubResource("44")
 texture = ExtResource("10")
 lifetime = 0.5
+fixed_fps = 0
 visibility_rect = Rect2(-14, 0, 26, 211)
 
 [node name="SprayPlume" type="AnimatedSprite2D" parent="."]

--- a/classes/player/player.tscn
+++ b/classes/player/player.tscn
@@ -1309,6 +1309,8 @@ position = Vector2(0, 10)
 shape = SubResource("6")
 
 [node name="SprayViewport" type="SubViewport" parent="."]
+disable_3d = true
+positional_shadow_atlas_16_bits = false
 size = Vector2i(640, 180)
 render_target_update_mode = 3
 

--- a/shaders/distance_field.gdshader
+++ b/shaders/distance_field.gdshader
@@ -1,23 +1,30 @@
 // made by RandomCatDude for revamped fludd particle fx
 shader_type canvas_item;
 
-uniform int particles_anim_h_frames;
-uniform int particles_anim_v_frames;
+uniform ivec2 frame_count;
 
 void vertex() {
-	float h_frames = float(particles_anim_h_frames);
-	float v_frames = float(particles_anim_v_frames);
-	VERTEX.xy /= vec2(h_frames, v_frames);
-	float particle_total_frames = float(particles_anim_h_frames * particles_anim_v_frames);
-	float particle_frame = floor(INSTANCE_CUSTOM.z * float(particle_total_frames));
+	vec2 frames = vec2(frame_count);
+	float frames_total = frames.x * frames.y;
 	
-	particle_frame = mod(particle_frame, particle_total_frames);
+	// By default, the particle will size itself to the entire texture.
+	// Downsize vertices and UVs to fit the size of one frame instead.
+	VERTEX.xy /= frames;
+	UV /= frames;
 	
-	UV /= vec2(h_frames, v_frames);
-	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);
+	// Pick a random frame for this particle.
+	// (INSTANCE_CUSTOM.z is a random seed.)
+	float chosen_frame = floor(INSTANCE_CUSTOM.z * frames_total);
+	chosen_frame = mod(chosen_frame, frames_total);
+	// Place the UVs on that frame.
+	UV += vec2(
+		mod(chosen_frame, frames.x) / frames.x, // Extract column
+		floor((chosen_frame + 0.5) / frames.x) / frames.y // Extract row
+	);
 }
 
 void fragment()
 {
+	// Cut it off by a threshold. Above is white; below is black.
 	COLOR.a = floor(texture(TEXTURE, UV).a + COLOR.a - 0.01);
 }

--- a/shaders/distance_field.gdshader
+++ b/shaders/distance_field.gdshader
@@ -2,6 +2,7 @@
 shader_type canvas_item;
 
 uniform ivec2 frame_count = ivec2(2, 2);
+uniform float cutoff_threshold: hint_range(0, 1) = 0.01;
 
 void vertex() {
 	vec2 frames = vec2(frame_count);
@@ -26,5 +27,5 @@ void vertex() {
 void fragment()
 {
 	// Cut it off by a threshold. Above is white; below is black.
-	COLOR.a = floor(texture(TEXTURE, UV).a + COLOR.a - 0.01);
+	COLOR.a = floor(texture(TEXTURE, UV).a + COLOR.a - cutoff_threshold);
 }

--- a/shaders/distance_field.gdshader
+++ b/shaders/distance_field.gdshader
@@ -25,11 +25,16 @@ void vertex() {
 }
 
 void fragment()
-{
-	// Cut it off by a threshold. Above is white; below is black.
-	COLOR.a = floor(
-		texture(TEXTURE, UV).a +
-		COLOR.a +
-		expand_reduce * COLOR.a
-	);
+{	
+	// Take the default alpha (vertex color times texture).
+	float new_alpha = COLOR.a;
+	// Expand/reduce the alpha.
+	new_alpha *= 1.0 + expand_reduce;
+	// Add the raw texture onto it. This bypasses vertex colors, meaning
+	// adding it pushes everything we care about above 1.
+	// (We can't just add a flat 1 to everything--that'd make everything
+	// pass the floor test we do later!)
+	new_alpha += texture(TEXTURE, UV).a;
+	// Finally, cut off the fraction. Anything above 1 will be kept.
+	COLOR.a = floor(new_alpha);
 }

--- a/shaders/distance_field.gdshader
+++ b/shaders/distance_field.gdshader
@@ -2,7 +2,7 @@
 shader_type canvas_item;
 
 uniform ivec2 frame_count = ivec2(2, 2);
-uniform float cutoff_threshold: hint_range(0, 1) = 0.01;
+uniform float expand_reduce: hint_range(-1, 1) = 0.01;
 
 void vertex() {
 	vec2 frames = vec2(frame_count);
@@ -27,5 +27,9 @@ void vertex() {
 void fragment()
 {
 	// Cut it off by a threshold. Above is white; below is black.
-	COLOR.a = floor(texture(TEXTURE, UV).a + COLOR.a - cutoff_threshold);
+	COLOR.a = floor(
+		texture(TEXTURE, UV).a +
+		COLOR.a +
+		expand_reduce * COLOR.a
+	);
 }

--- a/shaders/distance_field.gdshader
+++ b/shaders/distance_field.gdshader
@@ -1,7 +1,7 @@
 // made by RandomCatDude for revamped fludd particle fx
 shader_type canvas_item;
 
-uniform ivec2 frame_count;
+uniform ivec2 frame_count = ivec2(2, 2);
 
 void vertex() {
 	vec2 frames = vec2(frame_count);

--- a/shaders/distance_field.tres
+++ b/shaders/distance_field.tres
@@ -6,3 +6,4 @@
 resource_local_to_scene = true
 shader = ExtResource("1")
 shader_parameter/frame_count = Vector2i(2, 2)
+shader_parameter/cutoff_threshold = 0.0

--- a/shaders/distance_field.tres
+++ b/shaders/distance_field.tres
@@ -5,5 +5,4 @@
 [resource]
 resource_local_to_scene = true
 shader = ExtResource("1")
-shader_parameter/particles_anim_h_frames = 2
-shader_parameter/particles_anim_v_frames = 2
+shader_parameter/frame_count = Vector2i(2, 2)

--- a/shaders/distance_field.tres
+++ b/shaders/distance_field.tres
@@ -6,4 +6,4 @@
 resource_local_to_scene = true
 shader = ExtResource("1")
 shader_parameter/frame_count = Vector2i(2, 2)
-shader_parameter/cutoff_threshold = 0.0
+shader_parameter/expand_reduce = 0.25


### PR DESCRIPTION
# Description of changes
Readjusts the FLUDD spray particle system to look close to 3.1 FLUDD spray. (It's not exact, for reasons me and @jaschutte couldn't quite pin down, but it's close enough.)

Exact changes include:
- Readjusting particle gravity/velocity ranges (1.5 times original) and sizes.
- Giving particle's shader an adjustable cutoff value, to adjust the "blobbiness" of spray particles.
- Adjusting said blobbiness. Particles were a little bit thinner than the 3.5 versions.

# Issue(s)
Closes #195.