### PR TITLE
Fix Cheep Cheep animations

### DIFF
--- a/classes/entity/enemy/cheep_cheep/cheep_cheep.tscn
+++ b/classes/entity/enemy/cheep_cheep/cheep_cheep.tscn
@@ -99,7 +99,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("29")
 }],
-"loop": true,
+"loop": false,
 "name": &"calmdown",
 "speed": 10.0
 }, {
@@ -185,7 +185,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("27")
 }],
-"loop": true,
+"loop": false,
 "name": &"notice",
 "speed": 10.0
 }]


### PR DESCRIPTION
# Description of changes
Sets Cheep Cheeps' transition animations to not loop. Animations fire different signals when they loop versus when they end, and because the code is wired to the end signal, it was never advancing to the loop portion....

# Issue(s)
Closes #238.