### PR TITLE
Updated .gitignore for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ main.tscn
 # Windows-specific ignores
 desktop.ini
 
+# MacOS-speciffic ignores
+.DS_Store
+
 # IDE-specific ignores
 .vscode/*
 


### PR DESCRIPTION
# Description of changes
Added a line on .gitignore that ignores `.DS_Store` files auto-generated by MacOS.

# Issue(s)
Not reported.