### PR TITLE
Fix ground pounding moving platforms

### DIFF
--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -9,7 +9,7 @@ const SLOW_SPIN_START_SPEED = 1
 const SLOW_SPIN_END_SPEED = 0.40
 const SLOW_SPIN_TIME = 60
 
-const POUND_ORIGIN_OFFSET = Vector2(0,-3) # Sprite origin is set to this during pound spin
+const POUND_ORIGIN_OFFSET = Vector2(-2,-3) # Sprite origin is set to this during pound spin
 const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
 const POUND_SPIN_RISE_TIME = 15
 
@@ -183,8 +183,8 @@ func _physics_process(_delta):
 						
 						# A little rising as we wind up makes it look real nice.
 						position.y = POUND_ORIGIN_OFFSET.y
-						position.y += POUND_SPIN_RISE_TIME - POUND_SPIN_RISE * min(parent.pound_spin_frames, POUND_SPIN_RISE_TIME)
-						print(position.y)
+						position.y -= POUND_SPIN_RISE * min(parent.pound_spin_frames,
+							POUND_SPIN_RISE_TIME)
 				parent.S.SPIN:
 					spin_logic()
 				parent.S.CROUCH:

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -10,8 +10,6 @@ const SLOW_SPIN_END_SPEED = 0.40
 const SLOW_SPIN_TIME = 60
 
 const POUND_ORIGIN_OFFSET = Vector2(0,-3) # Sprite origin is set to this during pound spin
-const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
-const POUND_SPIN_RISE_TIME = 15
 
 const SLIDE_MAX_SPEED: float = 5.0
 

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -180,11 +180,6 @@ func _physics_process(_delta):
 						
 						# Offset origin's X less at the start of the spin. (Looks better!?)
 						position.x *= parent.pound_spin_factor
-						
-						# A little rising as we wind up makes it look real nice.
-						position.y = POUND_ORIGIN_OFFSET.y
-						position.y += POUND_SPIN_RISE_TIME - POUND_SPIN_RISE * min(parent.pound_spin_frames, POUND_SPIN_RISE_TIME)
-						print(position.y)
 				parent.S.SPIN:
 					spin_logic()
 				parent.S.CROUCH:

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -10,6 +10,8 @@ const SLOW_SPIN_END_SPEED = 0.40
 const SLOW_SPIN_TIME = 60
 
 const POUND_ORIGIN_OFFSET = Vector2(0,-3) # Sprite origin is set to this during pound spin
+const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
+const POUND_SPIN_RISE_TIME = 15
 
 const SLIDE_MAX_SPEED: float = 5.0
 

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -9,7 +9,7 @@ const SLOW_SPIN_START_SPEED = 1
 const SLOW_SPIN_END_SPEED = 0.40
 const SLOW_SPIN_TIME = 60
 
-const POUND_ORIGIN_OFFSET = Vector2(-2,-3) # Sprite origin is set to this during pound spin
+const POUND_ORIGIN_OFFSET = Vector2(0,-3) # Sprite origin is set to this during pound spin
 const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
 const POUND_SPIN_RISE_TIME = 15
 
@@ -183,8 +183,8 @@ func _physics_process(_delta):
 						
 						# A little rising as we wind up makes it look real nice.
 						position.y = POUND_ORIGIN_OFFSET.y
-						position.y -= POUND_SPIN_RISE * min(parent.pound_spin_frames,
-							POUND_SPIN_RISE_TIME)
+						position.y += POUND_SPIN_RISE_TIME - POUND_SPIN_RISE * min(parent.pound_spin_frames, POUND_SPIN_RISE_TIME)
+						print(position.y)
 				parent.S.SPIN:
 					spin_logic()
 				parent.S.CROUCH:

--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -180,6 +180,11 @@ func _physics_process(_delta):
 						
 						# Offset origin's X less at the start of the spin. (Looks better!?)
 						position.x *= parent.pound_spin_factor
+						
+						# A little rising as we wind up makes it look real nice.
+						position.y = POUND_ORIGIN_OFFSET.y
+						position.y += POUND_SPIN_RISE_TIME - POUND_SPIN_RISE * min(parent.pound_spin_frames, POUND_SPIN_RISE_TIME)
+						print(position.y)
 				parent.S.SPIN:
 					spin_logic()
 				parent.S.CROUCH:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -498,7 +498,7 @@ func action_pound() -> void:
 				pound_state = Pound.SPIN
 				body_rotation = 0
 				pound_spin_frames = 0
-				pound_spin_sfx.play()	
+				pound_spin_sfx.play()
 	
 	if state == S.POUND and pound_state == Pound.SPIN:
 		off_ground()

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -465,32 +465,6 @@ const POUND_SPIN_SMOOTHING = 0.5 # Range from 0 to 1
 var pound_spin_frames: int = 0
 var pound_spin_factor: float = 0.0
 func action_pound() -> void:
-	if state == S.POUND and pound_state == Pound.SPIN:
-		off_ground()
-		pound_spin_frames += 1
-		# Spin frames normalized from 0-1.
-		# Min makes it stop after one full spin.
-		pound_spin_factor = min(float(pound_spin_frames) / POUND_SPIN_DURATION, 1)
-		# Blend between 0% and 100% smoothed animation.
-		pound_spin_factor = lerp(pound_spin_factor, sqrt(pound_spin_factor), POUND_SPIN_SMOOTHING)
-		
-		# Set rotation according to position in the animation.
-		body_rotation = TAU * pound_spin_factor
-		# Adjust rotation depending on our facing direction.
-		body_rotation *= facing_direction
-		
-		# Once spin animation ends, fall.
-		if pound_spin_frames >= POUND_TIME_TO_FALL:
-			# Reset sprite transforms.
-			clear_rotation_origin()
-			
-			body_rotation = 0
-			
-			pound_state = Pound.FALL
-			pound_land_frames = 15
-			vel.y = 8
-
-
 	if Input.is_action_pressed("pound"):
 		if state == S.DIVE and gp_dive_timer > 0:
 			var mag = vel.length()
@@ -525,6 +499,32 @@ func action_pound() -> void:
 				body_rotation = 0
 				pound_spin_frames = 0
 				pound_spin_sfx.play()
+	
+	
+	if state == S.POUND and pound_state == Pound.SPIN:
+		off_ground()
+		pound_spin_frames += 1
+		# Spin frames normalized from 0-1.
+		# Min makes it stop after one full spin.
+		pound_spin_factor = min(float(pound_spin_frames) / POUND_SPIN_DURATION, 1)
+		# Blend between 0% and 100% smoothed animation.
+		pound_spin_factor = lerp(pound_spin_factor, sqrt(pound_spin_factor), POUND_SPIN_SMOOTHING)
+		
+		# Set rotation according to position in the animation.
+		body_rotation = TAU * pound_spin_factor
+		# Adjust rotation depending on our facing direction.
+		body_rotation *= facing_direction
+		
+		# Once spin animation ends, fall.
+		if pound_spin_frames >= POUND_TIME_TO_FALL:
+			# Reset sprite transforms.
+			clear_rotation_origin()
+			
+			body_rotation = 0
+			
+			pound_state = Pound.FALL
+			pound_land_frames = 15
+			vel.y = 8
 
 
 const SPIN_TIME = 30

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -461,7 +461,6 @@ const POUND_TIME_TO_FALL = 18 # Time to move from pound spin to pound fall
 const _POUND_HANG_TIME = 9
 const POUND_SPIN_DURATION = POUND_TIME_TO_FALL - _POUND_HANG_TIME # Time the spin animation lasts
 const POUND_SPIN_SMOOTHING = 0.5 # Range from 0 to 1
-const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
 
 var pound_spin_frames: int = 0
 var pound_spin_factor: float = 0.0
@@ -515,8 +514,6 @@ func action_pound() -> void:
 		body_rotation = TAU * pound_spin_factor
 		# Adjust rotation depending on our facing direction.
 		body_rotation *= facing_direction
-		# A little rising as we wind up makes it look real nice.
-		vel.y = -POUND_SPIN_RISE
 		
 		# Once spin animation ends, fall.
 		if pound_spin_frames >= POUND_TIME_TO_FALL:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -466,6 +466,7 @@ var pound_spin_frames: int = 0
 var pound_spin_factor: float = 0.0
 func action_pound() -> void:
 	if state == S.POUND and pound_state == Pound.SPIN:
+		off_ground()
 		pound_spin_frames += 1
 		# Spin frames normalized from 0-1.
 		# Min makes it stop after one full spin.

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -498,8 +498,7 @@ func action_pound() -> void:
 				pound_state = Pound.SPIN
 				body_rotation = 0
 				pound_spin_frames = 0
-				pound_spin_sfx.play()
-	
+				pound_spin_sfx.play()	
 	
 	if state == S.POUND and pound_state == Pound.SPIN:
 		off_ground()

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -461,6 +461,7 @@ const POUND_TIME_TO_FALL = 18 # Time to move from pound spin to pound fall
 const _POUND_HANG_TIME = 9
 const POUND_SPIN_DURATION = POUND_TIME_TO_FALL - _POUND_HANG_TIME # Time the spin animation lasts
 const POUND_SPIN_SMOOTHING = 0.5 # Range from 0 to 1
+const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
 
 var pound_spin_frames: int = 0
 var pound_spin_factor: float = 0.0
@@ -514,6 +515,8 @@ func action_pound() -> void:
 		body_rotation = TAU * pound_spin_factor
 		# Adjust rotation depending on our facing direction.
 		body_rotation *= facing_direction
+		# A little rising as we wind up makes it look real nice.
+		vel.y = -POUND_SPIN_RISE
 		
 		# Once spin animation ends, fall.
 		if pound_spin_frames >= POUND_TIME_TO_FALL:


### PR DESCRIPTION
# Description of changes
<!-- Add in your changes and the importance of everything here -->
~~Removes the wind-up from character_sprite.gd (If we really want this effect, it should be implemented by actually moving the character instead of just the sprite, so physics can remain consistent)~~
Fixes the order of processing ground pound inputs. SIRIUS: This makes ground pounds work correctly on moving platforms.

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #179 