### PR TITLE
Apply pound windup animation to actual player position

### DIFF
--- a/classes/player/character_sprite.gd
+++ b/classes/player/character_sprite.gd
@@ -10,8 +10,6 @@ const SLOW_SPIN_END_SPEED = 0.40
 const SLOW_SPIN_TIME = 60
 
 const POUND_ORIGIN_OFFSET = Vector2(-2,-3) # Sprite origin is set to this during pound spin
-const POUND_SPIN_RISE = 1 # How much the player rises each frame of pound
-const POUND_SPIN_RISE_TIME = 15
 
 const SLIDE_MAX_SPEED: float = 5.0
 
@@ -180,11 +178,6 @@ func _physics_process(_delta):
 						
 						# Offset origin's X less at the start of the spin. (Looks better!?)
 						position.x *= parent.pound_spin_factor
-						
-						# A little rising as we wind up makes it look real nice.
-						position.y = POUND_ORIGIN_OFFSET.y
-						position.y -= POUND_SPIN_RISE * min(parent.pound_spin_frames,
-							POUND_SPIN_RISE_TIME)
 				parent.S.SPIN:
 					spin_logic()
 				parent.S.CROUCH:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -921,7 +921,7 @@ func player_fall() -> void:
 		vel = Vector2.ZERO
 		# A little rising during the wind-up makes it look real nice.
 		if pound_spin_frames <= POUND_SPIN_RISE_TIME:
-			vel.y -= POUND_SPIN_RISE_AMOUNT
+			vel.y = -POUND_SPIN_RISE_AMOUNT
 	else:
 		if state == S.POUND and pound_state == Pound.FALL:
 			fall_adjust += 0.814

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -1371,7 +1371,6 @@ func switch_state(new_state):
 			hitbox.shape.size = STAND_BOX_SIZE
 			camera.position_smoothing_speed = 5
 			clear_rotation_origin()
-
 	
 	# On any state change, reset the following things:
 	pound_state = Pound.NONE

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -460,6 +460,10 @@ func wall_stop() -> void:
 const POUND_TIME_TO_FALL = 18 # Time to move from pound spin to pound fall
 const _POUND_HANG_TIME = 9
 const POUND_SPIN_DURATION = POUND_TIME_TO_FALL - _POUND_HANG_TIME # Time the spin animation lasts
+## How many frames the player will rise during the pound spin.
+const POUND_SPIN_RISE_TIME = 15
+## How much the player rises each frame of the pound spin.
+const POUND_SPIN_RISE_AMOUNT = 1
 const POUND_SPIN_SMOOTHING = 0.5 # Range from 0 to 1
 
 var pound_spin_frames: int = 0
@@ -913,7 +917,11 @@ func ground_failsafe_condition() -> bool:
 func player_fall() -> void:
 	var fall_adjust = vel.y # used to adjust downward acceleration to account for framerate difference
 	if state == S.POUND and pound_state == Pound.SPIN:
+		# Don't move during the pound spin.
 		vel = Vector2.ZERO
+		# A little rising during the wind-up makes it look real nice.
+		if pound_spin_frames <= POUND_SPIN_RISE_TIME:
+			vel.y -= POUND_SPIN_RISE_AMOUNT
 	else:
 		if state == S.POUND and pound_state == Pound.FALL:
 			fall_adjust += 0.814


### PR DESCRIPTION
# Description of changes
The pound spin animation appears to lift the player up slightly before the drop. This PR makes it so that this lifting isn't just visual, but rather actually affects the player's position.

This does have the side effect of giving the player a new movement option. Players likely assumed they already had this option, so this probably isn't a huge change to the play experience. Nonetheless, it deserves a mention.

Shout out to @Kuma-Boo for coming up with the apply-to-velocity method in PR #241. It's simple enough that I can't believe I ever considered applying the lift directly to the player position.

# Issue(s)
Closes #177.