### PR TITLE
Fix tipping log jitter

### DIFF
--- a/classes/solid/telescoping/tipping_log/tipping_log.gd
+++ b/classes/solid/telescoping/tipping_log/tipping_log.gd
@@ -48,6 +48,7 @@ func physics_step():
 		body.set_up_direction(Vector2.UP)
 		body.set_floor_stop_on_slope_enabled(true)
 		body.move_and_slide()
+		body.apply_floor_snap()
 
 
 func set_disabled(val):


### PR DESCRIPTION
# Description of changes
Fixes jittering collision on tipping logs by forcing the player to snap to the floor.

# Issue(s)
Closes #248