### PR TITLE
Fix leftover references to bylight.tres

### DIFF
--- a/gui/hud/level_info.gd
+++ b/gui/hud/level_info.gd
@@ -1,6 +1,6 @@
 extends Control
 
-const BYLIGHT = preload("res://fonts/bylight/bylight.tres")
+const BYLIGHT = preload("res://fonts/bylight/bylight.otf")
 const RUBY = preload("res://fonts/red/gui_red.fnt")
 
 @onready var level_name = $Divider/MainContainer/LevelNamePanel/ScaleContainer/LevelName

--- a/scenes/menus/level_designer/ldui/themes/ld_theme.tres
+++ b/scenes/menus/level_designer/ldui/themes/ld_theme.tres
@@ -6,7 +6,7 @@
 [ext_resource type="StyleBox" uid="uid://dhliyj8vycb7q" path="res://gui/boxes/menu_box_normal.tres" id="4_adjba"]
 [ext_resource type="StyleBox" uid="uid://b54n55rde5xf6" path="res://gui/boxes/menu_box_pressed.tres" id="5_tl50b"]
 [ext_resource type="StyleBox" uid="uid://cgemqfbup0gd8" path="res://gui/boxes/menu_box_drop.tres" id="6_g5imp"]
-[ext_resource type="FontFile" uid="uid://caqw4rjpuutk8" path="res://fonts/bylight/bylight.tres" id="7_44i8b"]
+[ext_resource type="FontFile" uid="uid://caqw4rjpuutk8" path="res://fonts/bylight/bylight.otf" id="7_44i8b"]
 
 [sub_resource type="AtlasTexture" id="8"]
 region = Rect2(0, 0, 14, 15)

--- a/scenes/menus/visual_pipescript/node.gd
+++ b/scenes/menus/visual_pipescript/node.gd
@@ -4,7 +4,7 @@ extends NinePatchRect
 @onready var compiler = $"/root/Main/PipeScript/VisualCompiler"
 @onready var graph = get_parent()
 
-const BYLIGHT = preload("res://fonts/bylight/bylight.tres")
+const BYLIGHT = preload("res://fonts/bylight/bylight.otf")
 const STYLEBOX = preload("res://scenes/menus/visual_pipescript/line_edit_style.stylebox")
 const EDITOR_THEME = preload("res://scenes/menus/visual_pipescript/visual_editor_theme.tres")
 

--- a/scenes/menus/visual_pipescript/node_placer.gd
+++ b/scenes/menus/visual_pipescript/node_placer.gd
@@ -1,7 +1,7 @@
 extends Node
 
 const PHANTOM_STYLE = preload("res://scenes/menus/visual_pipescript/phantom_style.tres")
-const BYLIGHT = preload("res://fonts/bylight/bylight.tres")
+const BYLIGHT = preload("res://fonts/bylight/bylight.otf")
 const EDITOR_THEME = preload("res://scenes/menus/visual_pipescript/visual_editor_theme.tres")
 
 @onready var graph = $Graph


### PR DESCRIPTION
# Description of changes
As of #253, `bylight.tres` has been removed as redundant (in favor of `bylight.otf`), but was still referenced by some scripts (and the LD theme I guess). Fix those references to point to the still-existing file.

# Issue(s)
Cleans up a hasty review process on #253.