### PR TITLE
Disable some toolscripts

### DIFF
--- a/classes/console/console.gd
+++ b/classes/console/console.gd
@@ -270,7 +270,7 @@ func _input(event):
 	logger.offset_top = -40 - (Singleton.line_count + 1) * (logger.get_theme_font("normal_font").get_height() + 1)
 
 func display_completion(query: String, options: Array):
-	suggestions_log.text = ""
+	suggestions_log.clear()
 	
 	var sorted_options = []
 	for option in options:

--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -1,4 +1,3 @@
-@tool
 extends AnimatedSprite2D
 
 @onready var hurtbox = $Damage
@@ -34,11 +33,10 @@ func set_color(new_color):
 
 
 func _ready():
-	if !Engine.is_editor_hint():
-		flip_h = mirror
-		frame = hash(position.x + position.y * PI) % 6
-		if not disabled:
-			play()
+	flip_h = mirror
+	frame = hash(position.x + position.y * PI) % 6
+	if not disabled:
+		play()
 
 
 func _exit_tree():
@@ -100,8 +98,7 @@ func set_disabled(val):
 	disabled = val
 	hurtbox.monitoring = !val
 	top_collision.monitoring = !val
-	if !Engine.is_editor_hint():
-		if disabled:
-			stop()
-		else:
-			play()
+	if disabled:
+		stop()
+	else:
+		play()

--- a/classes/entity/enemy/thwomp/thwomp.gd
+++ b/classes/entity/enemy/thwomp/thwomp.gd
@@ -1,4 +1,3 @@
-@tool
 extends StaticBody2D
 
 @onready var detect_area = $DetectionBox
@@ -93,8 +92,6 @@ func attack():
 
 
 func _physics_process(delta):
-	if Engine.is_editor_hint(): return
-	
 	_timer += delta
 	
 	match _state:

--- a/classes/interactable/door/door_skin.gd
+++ b/classes/interactable/door/door_skin.gd
@@ -1,4 +1,3 @@
-@tool
 class_name DoorSkin
 extends SpriteFrames
 

--- a/classes/interactable/interactable_dialog.gd
+++ b/classes/interactable/interactable_dialog.gd
@@ -7,7 +7,7 @@ extends Interactable
 @export var can_pivot: bool = false
 @export var back_sprite: bool = false
 
-@onready var dialog = $"/root/Main/Player/Camera/HUD/HUDControl/DialogBox" if !Engine.is_editor_hint() else null
+@onready var dialog = $"/root/Main/Player/Camera/HUD/HUDControl/DialogBox"
 
 
 func _interact_with(body):

--- a/classes/interactable/npc/toad/toad.gd
+++ b/classes/interactable/npc/toad/toad.gd
@@ -1,4 +1,3 @@
-@tool
 class_name Toad
 extends InteractableDialog
 
@@ -61,9 +60,6 @@ func _ready():
 	set_spot(spot)
 	set_skin(skin)
 	
-	if Engine.is_editor_hint():
-		return
-		
 	sprite.frame = fmod(position.x + position.y * PI, 7)
 	sprite.play()
 

--- a/classes/solid/moving_platform/pivot.gd
+++ b/classes/solid/moving_platform/pivot.gd
@@ -1,4 +1,3 @@
-@tool
 extends Node2D
 
 const dot_tex = preload("./dot.png")
@@ -54,8 +53,7 @@ func refresh_ring():
 
 
 func _physics_process(_delta):
-	if !Engine.is_editor_hint():
-		for i in $Platforms.get_child_count():
-			var angle = (2 * PI / count) * i + offset + rot
-			$Platforms.get_child(i).position = Vector2(cos(angle) * radius, sin(angle) * radius)
-		rot += (2 * PI / 360) * (speed / 10)
+	for i in $Platforms.get_child_count():
+		var angle = (2 * PI / count) * i + offset + rot
+		$Platforms.get_child(i).position = Vector2(cos(angle) * radius, sin(angle) * radius)
+	rot += (2 * PI / 360) * (speed / 10)

--- a/classes/solid/telescoping/telescoping.gd
+++ b/classes/solid/telescoping/telescoping.gd
@@ -1,4 +1,3 @@
-@tool
 class_name Telescoping
 extends Node2D
 # Root class for objects that can change lengths, such as clouds and tipping logs.

--- a/classes/solid/telescoping/tipping_log/tipping_log.gd
+++ b/classes/solid/telescoping/tipping_log/tipping_log.gd
@@ -1,4 +1,3 @@
-@tool
 class_name TippingLog
 extends Telescoping
 
@@ -17,7 +16,7 @@ func set_width(val):
 
 
 func _physics_process(_delta):
-	if !Engine.is_editor_hint() and !disabled:
+	if !disabled:
 		physics_step()
 
 

--- a/classes/zone/trigger/warpzone/warp_zone.gd
+++ b/classes/zone/trigger/warpzone/warp_zone.gd
@@ -1,4 +1,3 @@
-@tool
 extends Area2D
 
 @export var sweep_direction: Vector2


### PR DESCRIPTION
# Description of changes
Disable some toolscripts that are no longer relevant, since the scene editor will not be used for future level creation.

This is on the 4.1 branch, because the toolscript syntax changed in 4.1.

# Issue(s)
I hoped this would resolve #255, but it doesn't.