### PR TITLE
Fix palette material UIDs regenerating

### DIFF
--- a/classes/entity/enemy/koopa/parakoopa.gd
+++ b/classes/entity/enemy/koopa/parakoopa.gd
@@ -21,18 +21,24 @@ const color_presets = [
 
 @export var disabled = false: set = set_disabled
 @export var mirror = false
-@export var color: Koopa.ShellColor = Koopa.ShellColor.GREEN: set = set_color
+@export var color := Koopa.ShellColor.GREEN
 
 
 func set_color(new_color):
 	for i in range(3):
 		material.set_shader_parameter("color" + str(i), color_presets[new_color][i])
-	color = new_color
 	koopa.color = color
 	shell.color = color
 
 
 func _ready():
+	# Ensure that the material is unique so we can set its parameters.
+	# "Local to scene" causes issues with source control, because UIDs are refreshed on loading the scene.
+	# This method refreshes them at runtime instead of in the editor.
+	material = material.duplicate()
+	
+	set_color(color)
+	
 	flip_h = mirror
 	frame = hash(position.x + position.y * PI) % 6
 	if not disabled:

--- a/classes/interactable/npc/toad/toad.gd
+++ b/classes/interactable/npc/toad/toad.gd
@@ -39,27 +39,27 @@ const skin_presets = [
 	],
 ]
 
-@export_enum("Red", "Green", "Blue", "Yellow", "Purple") var spot = 0: set = set_spot
-@export_range(0, 1) var skin = 0: set = set_skin
+@export_enum("Red", "Green", "Blue", "Yellow", "Purple") var spot: int = 0
+@export_range(0, 1) var skin: int = 0
 
 
 func set_spot(new_spot):
 	for i in range(2):
 		material.set_shader_parameter("color" + str(i), spot_presets[new_spot][i])
-	spot = new_spot
 
 
 func set_skin(new_skin):
 	for i in range(4):
 		material.set_shader_parameter("color" + str(i + 2), skin_presets[new_skin][i])
-	skin = new_skin
+
+
+func _init():
+	material = material.duplicate()
+	set_spot(spot)
+	set_skin(skin)
 
 
 func _ready():
-	# Sets up palette when instancing in the editor
-	set_spot(spot)
-	set_skin(skin)
-	
 	sprite.frame = fmod(position.x + position.y * PI, 7)
 	sprite.play()
 

--- a/scenes/levels/tutorial_1/tutorial_1_3.tscn
+++ b/scenes/levels/tutorial_1/tutorial_1_3.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=58 format=3 uid="uid://cbgdqcf3jpq5o"]
+[gd_scene load_steps=56 format=3 uid="uid://cbgdqcf3jpq5o"]
 
-[ext_resource type="Shader" path="res://shaders/palette.gdshader" id="1"]
 [ext_resource type="PackedScene" uid="uid://uxujeycb0ytl" path="res://classes/solid/terrain/terrain_polygon.tscn" id="7"]
 [ext_resource type="PackedScene" uid="uid://hr76pxvm5b6f" path="res://classes/water/water.tscn" id="8"]
 [ext_resource type="PackedScene" uid="uid://coyt8uat1063g" path="res://classes/solid/fungus_platform/fungus_stem.tscn" id="10"]
@@ -26,16 +25,6 @@
 [ext_resource type="PackedScene" uid="uid://dmvmvmv3te56c" path="res://classes/decorative/arrow/arrow.tscn" id="28"]
 [ext_resource type="PackedScene" uid="uid://r5f5n67eg4l4" path="res://classes/entity/passive/goonie/goonie.tscn" id="29"]
 [ext_resource type="PackedScene" uid="uid://d1alvph4yehre" path="res://classes/decorative/butterfly/butterfly.tscn" id="30"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_ltupr"]
-resource_local_to_scene = true
-shader = ExtResource("1")
-shader_parameter/color0 = Color(0.796078, 0.368627, 0.0352941, 1)
-shader_parameter/color1 = Color(0.568627, 0.0705882, 0.188235, 1)
-shader_parameter/color2 = Color(0.478431, 0.258824, 0.203922, 1)
-shader_parameter/color3 = Color(1, 1, 0, 1)
-shader_parameter/color4 = Color(1, 0, 1, 1)
-shader_parameter/color5 = Color(0, 1, 1, 1)
 
 [sub_resource type="AtlasTexture" id="11"]
 atlas = ExtResource("13_p3ewm")
@@ -397,7 +386,6 @@ lines = Array[String](["[@n,Gil Board]To refill the [color=#f7c55f]F.L.U.D.D.[/c
 [node name="Enemy" type="Node2D" parent="Items"]
 
 [node name="Parakoopa" parent="Items/Enemy" instance=ExtResource("20")]
-material = SubResource("ShaderMaterial_ltupr")
 position = Vector2(1335.47, -15.5049)
 sprite_frames = SubResource("8")
 frame = 4

--- a/scenes/levels/tutorial_1/tutorial_1_4.tscn
+++ b/scenes/levels/tutorial_1/tutorial_1_4.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=47 format=3 uid="uid://be6h11571m34p"]
+[gd_scene load_steps=43 format=3 uid="uid://be6h11571m34p"]
 
 [ext_resource type="PackedScene" uid="uid://uxujeycb0ytl" path="res://classes/solid/terrain/terrain_polygon.tscn" id="14"]
 [ext_resource type="PackedScene" uid="uid://fxxe0l6ugcov" path="res://classes/solid/moving_platform/pivot.tscn" id="15"]
@@ -26,18 +26,7 @@
 [ext_resource type="PackedScene" uid="uid://c1fox2fi1q2ga" path="res://classes/zone/camera_area/camera_area.tscn" id="36"]
 [ext_resource type="PackedScene" uid="uid://bclig81j8t46n" path="res://classes/zone/trigger/warpzone/warp_zone.tscn" id="37"]
 [ext_resource type="PackedScene" uid="uid://x15gxnqh87uj" path="res://classes/decorative/fossil/fossil.tscn" id="39"]
-[ext_resource type="Shader" path="res://shaders/palette.gdshader" id="40"]
 [ext_resource type="PackedScene" uid="uid://bb0uyyyri5y2r" path="res://classes/interactable/npc/toad/toad.tscn" id="41"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_4sksv"]
-resource_local_to_scene = true
-shader = ExtResource("40")
-shader_parameter/color0 = Color(0.611765, 0.772549, 0.427451, 1)
-shader_parameter/color1 = Color(0.121569, 0.533333, 0.478431, 1)
-shader_parameter/color2 = Color(0.168627, 0.290196, 0.239216, 1)
-shader_parameter/color3 = Color(1, 1, 0, 1)
-shader_parameter/color4 = Color(1, 0, 1, 1)
-shader_parameter/color5 = Color(0, 1, 1, 1)
 
 [sub_resource type="AtlasTexture" id="11"]
 atlas = ExtResource("16_0a56l")
@@ -96,16 +85,6 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_44eex"]
-resource_local_to_scene = true
-shader = ExtResource("40")
-shader_parameter/color0 = Color(0.611765, 0.772549, 0.427451, 1)
-shader_parameter/color1 = Color(0.121569, 0.533333, 0.478431, 1)
-shader_parameter/color2 = Color(0.168627, 0.290196, 0.239216, 1)
-shader_parameter/color3 = Color(1, 1, 0, 1)
-shader_parameter/color4 = Color(1, 0, 1, 1)
-shader_parameter/color5 = Color(0, 1, 1, 1)
-
 [sub_resource type="AtlasTexture" id="5"]
 atlas = ExtResource("23_lh6p4")
 region = Rect2(0, 0, 34, 24)
@@ -160,16 +139,6 @@ animations = [{
 "name": &"yellow",
 "speed": 5.0
 }]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_2oim1"]
-resource_local_to_scene = true
-shader = ExtResource("40")
-shader_parameter/color0 = Color(0.87451, 0.376471, 0.258824, 1)
-shader_parameter/color1 = Color(0.713726, 0.278431, 0.156863, 1)
-shader_parameter/color2 = Color(0.984314, 0.827451, 0.584314, 1)
-shader_parameter/color3 = Color(0.898039, 0.623529, 0.32549, 1)
-shader_parameter/color4 = Color(0.87451, 0.376471, 0.258824, 1)
-shader_parameter/color5 = Color(0.713726, 0.278431, 0.156863, 1)
 
 [node name="Main" type="Node2D"]
 
@@ -430,13 +399,11 @@ position = Vector2(-3, -280)
 position = Vector2(262, 179)
 
 [node name="Parakoopa" parent="Items/Enemy" instance=ExtResource("35")]
-material = SubResource("ShaderMaterial_4sksv")
 position = Vector2(-638, -668)
 sprite_frames = SubResource("8")
 frame = 0
 
 [node name="Parakoopa2" parent="Items/Enemy" instance=ExtResource("35")]
-material = SubResource("ShaderMaterial_44eex")
 position = Vector2(-57, -330)
 sprite_frames = SubResource("8")
 frame = 0
@@ -562,7 +529,6 @@ position = Vector2(761, -540)
 lines = Array[String](["You've reached the end of the [color=#f7c55f]Tiny Demo![/color]", "We hope you enjoyed it, and stay tuned for more!"])
 
 [node name="Toad" parent="Items" instance=ExtResource("41")]
-material = SubResource("ShaderMaterial_2oim1")
 position = Vector2(-715, -312)
 lines = Array[String](["[@c,toad][@m,anger][@n,Ang.T]Unused dialog...[@p,10] Is that [color=#f28d7c]really[/color] all I'm good for!?"])
 

--- a/shaders/palette.tres
+++ b/shaders/palette.tres
@@ -3,11 +3,10 @@
 [ext_resource type="Shader" path="res://shaders/palette.gdshader" id="1"]
 
 [resource]
-resource_local_to_scene = true
 shader = ExtResource("1")
-shader_parameter/color0 = Color(0.611765, 0.772549, 0.427451, 1)
-shader_parameter/color1 = Color(0.121569, 0.533333, 0.478431, 1)
-shader_parameter/color2 = Color(0.168627, 0.290196, 0.239216, 1)
+shader_parameter/color0 = Color(1, 0, 0, 1)
+shader_parameter/color1 = Color(0, 1, 0, 1)
+shader_parameter/color2 = Color(0, 0, 1, 1)
 shader_parameter/color3 = Color(1, 1, 0, 1)
 shader_parameter/color4 = Color(1, 0, 1, 1)
 shader_parameter/color5 = Color(0, 1, 1, 1)


### PR DESCRIPTION
Fix an issue with the palette material causing the UIDs of its duplicates in the scene file to change frequently without designer input.

# Issue(s)
Closes #255