### PR TITLE
Fix t1r4 color block being white instead of color

### DIFF
--- a/scenes/levels/tutorial_1/tutorial_1_4.tscn
+++ b/scenes/levels/tutorial_1/tutorial_1_4.tscn
@@ -266,11 +266,9 @@ width = 6
 [node name="RotatingBlocks" type="Node2D" parent="Items"]
 
 [node name="RotatingBlock" parent="Items/RotatingBlocks" instance=ExtResource("21")]
-modulate = Color(1, 1, 1, 0.5)
 position = Vector2(-355, -296)
 size = Vector2(92, 92)
 wait = 90
-type = 2
 
 [node name="RotatingBlock2" parent="Items/RotatingBlocks" instance=ExtResource("21")]
 modulate = Color(1, 1, 1, 0.5)


### PR DESCRIPTION
# Description of changes
In Tutorial 1 Room 4, the first rotating block is white translucent. It should be color. This fixes that.