### PR TITLE
Fix odd behaviour when player moves backwards during the uncrouch animation

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -685,14 +685,13 @@ func player_control_x() -> void:
 	var dir = get_walk_direction()
 	if dir != 0:
 		if pound_state != Pound.SPIN and (state != S.CROUCH or crouch_resetting):
-			if (
-				state & (
+			var canTurnAround: bool = state & (
 					S.NEUTRAL
 					| S.SPIN
 					| S.TRIPLE_JUMP
 					| S.ROLLOUT
 				) or crouch_resetting
-			):
+			if canTurnAround:
 				facing_direction = dir # Will never be 0
 			if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:
 				if state == S.POUND:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -691,7 +691,7 @@ func player_control_x() -> void:
 					| S.SPIN
 					| S.TRIPLE_JUMP
 					| S.ROLLOUT
-				)
+				) or crouch_resetting
 			):
 				facing_direction = dir # Will never be 0
 			if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -685,13 +685,13 @@ func player_control_x() -> void:
 	var dir = get_walk_direction()
 	if dir != 0:
 		if pound_state != Pound.SPIN and (state != S.CROUCH or crouch_resetting):
-			var canTurnAround: bool = state & (
+			var can_turn_around: bool = state & (
 					S.NEUTRAL
 					| S.SPIN
 					| S.TRIPLE_JUMP
 					| S.ROLLOUT
 				) or crouch_resetting
-			if canTurnAround:
+			if can_turn_around:
 				facing_direction = dir # Will never be 0
 			if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:
 				if state == S.POUND:


### PR DESCRIPTION
# Description of changes

Make it so that uncrouching (crouch resetting) is counted as a valid case for allowing a turn around while moving. This prevents the odd behaviour of moving backwards while the uncrouch animation is still playing.

# Issue(s)
Closes #180