### PR TITLE
Allow turning around while crouched

### DIFF
--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -694,22 +694,22 @@ func player_control_x() -> void:
 				) or crouch_resetting
 			if can_turn_around:
 				facing_direction = dir # Will never be 0
-		if pound_state != Pound.SPIN and (state != S.CROUCH or crouch_resetting):
-			if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:
-				if state == S.POUND:
-					vel.x = 0
-				elif state != S.DIVE:
-					vel.x += dir * WALK_ACCEL
-			else:
-				var core_vel = dir * max((AIR_ACCEL - dir * vel.x) / (AIR_SPEED_CAP / (3 * FPS_MOD)), 0)
-				if state & (S.TRIPLE_JUMP | S.SPIN | S.BACKFLIP | S.HURT):
-					vel.x += core_vel / (1.5 / FPS_MOD)
-				elif state & (S.DIVE | S.ROLLOUT):
-					vel.x += core_vel / (8 / FPS_MOD)
-				elif state == S.POUND:
-					vel.x += core_vel / (2 / FPS_MOD)
+			if state != S.CROUCH or crouch_resetting:
+				if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:
+					if state == S.POUND:
+						vel.x = 0
+					elif state != S.DIVE:
+						vel.x += dir * WALK_ACCEL
 				else:
-					vel.x += core_vel
+					var core_vel = dir * max((AIR_ACCEL - dir * vel.x) / (AIR_SPEED_CAP / (3 * FPS_MOD)), 0)
+					if state & (S.TRIPLE_JUMP | S.SPIN | S.BACKFLIP | S.HURT):
+						vel.x += core_vel / (1.5 / FPS_MOD)
+					elif state & (S.DIVE | S.ROLLOUT):
+						vel.x += core_vel / (8 / FPS_MOD)
+					elif state == S.POUND:
+						vel.x += core_vel / (2 / FPS_MOD)
+					else:
+						vel.x += core_vel
 
 
 func get_walk_direction() -> int:

--- a/classes/player/player.gd
+++ b/classes/player/player.gd
@@ -684,15 +684,17 @@ const AIR_SPEED_CAP: float = 20.0 * FPS_MOD
 func player_control_x() -> void:
 	var dir = get_walk_direction()
 	if dir != 0:
-		if pound_state != Pound.SPIN and (state != S.CROUCH or crouch_resetting):
+		if pound_state != Pound.SPIN:
 			var can_turn_around: bool = state & (
 					S.NEUTRAL
 					| S.SPIN
 					| S.TRIPLE_JUMP
 					| S.ROLLOUT
+					| S.CROUCH
 				) or crouch_resetting
 			if can_turn_around:
 				facing_direction = dir # Will never be 0
+		if pound_state != Pound.SPIN and (state != S.CROUCH or crouch_resetting):
 			if (grounded or (state & (S.ROLLOUT | S.BACKFLIP | S.DIVE | S.NEUTRAL) and ground_except)) and !swimming:
 				if state == S.POUND:
 					vel.x = 0


### PR DESCRIPTION
# Description of changes
Allow turning around while crouching by adding the crouching state to the list of valid cases that allow turning around.

Quoting myself from #284:
> This would allow the player to correct the direction in which they are facing while crouched, instead of having to stand up first before turning around; similar to how it works in many modern Mario games.
>
> This also makes it more comfortable for the player to crouch to perform a backflip, as they will no longer need to uncrouch to turn around in case they suddenly decide they need to do a backflip the other way, which risks an accidental dive. This scenario is the one that I believe would benefit the most from this proposal.

However, even though this is but a tiny change in code, I do think that this could be a slightly major change that will impact movement tech; and I think it'd be appropriate to discuss about it before making these changes... unless I'm overthinking it. I'd appreciate some feedback regardless.

Let me know about any suggestions, and if there should be any balancing that should be done beforehand.

# Issue(s)
Closes #284