### PR TITLE
Fix koopa producing two shells if both stomped and struck

### DIFF
--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -67,9 +67,10 @@ func _hurt_struck(body):
 
 
 func into_shell(vel_x):
-	var inst = SHELL_PREFAB.instantiate()
-	inst.position = position + Vector2(0, 7.5)
-	inst.color = color
-	inst.vel = Vector2(vel_x, 0)
-	get_parent().call_deferred("add_child", inst)
-	queue_free()
+	if !self.is_queued_for_deletion():
+		var inst = SHELL_PREFAB.instantiate()
+		inst.position = position + Vector2(0, 7.5)
+		inst.color = color
+		inst.vel = Vector2(vel_x, 0)
+		get_parent().call_deferred("add_child", inst)
+		queue_free()

--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -67,8 +67,11 @@ func _hurt_struck(body):
 
 
 func into_shell(vel_x):
-	# If this object is queued for deletion, we know not to spawn a second
-	# shell.
+	# Only do anything if this koopa is NOT queued for deletion.
+	# If it is, we know it's already been hit by an attack (or it's meant to be
+	# outright deleted by next frame).
+	# This should fix a bug wherein stomping and spinning the koopa in the same
+	# frame spawns two shells, one for each attack that landed.
 	if !is_queued_for_deletion():
 		# Create a new shell at this koopa's position.
 		var inst = SHELL_PREFAB.instantiate()

--- a/classes/entity/enemy/koopa/koopa.gd
+++ b/classes/entity/enemy/koopa/koopa.gd
@@ -67,10 +67,15 @@ func _hurt_struck(body):
 
 
 func into_shell(vel_x):
-	if !self.is_queued_for_deletion():
+	# If this object is queued for deletion, we know not to spawn a second
+	# shell.
+	if !is_queued_for_deletion():
+		# Create a new shell at this koopa's position.
 		var inst = SHELL_PREFAB.instantiate()
 		inst.position = position + Vector2(0, 7.5)
 		inst.color = color
 		inst.vel = Vector2(vel_x, 0)
+		# Add it to the world.
 		get_parent().call_deferred("add_child", inst)
+		
 		queue_free()


### PR DESCRIPTION
# Description of changes
Possibly fixes a bug where koopas could split into two shells under specific circumstances. (I'm not quite precise enough with timing to repro it myself 😖)

Ticket &70cff suggests that the problem occurs when a stomp and spin both hit the koopa at once. A code review bears this theory out: if both the stomp and strike functions run in the same frame, the spawn-shell-and-delete-self function `into_shell` is called both times.

To fix this, I modified `into_shell` to do nothing if the koopa is queued for deletion (which it always will be after the function is called once). I could easily have modified the call sites instead, but this way there's only one new if statement, not two, and no extra thought is required when using `into_shell` in the future.

# Issue(s)
Theoretically closes ticket &70cff, and a longstanding bug noticed by several people on Discord (@nyanpasu64 and possibly Vexxter).