### PR TITLE
Disabled v-sync, capped FPS to 60

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="Super Mario 63 Redux"
 run/main_scene="res://scenes/menus/title/title.tscn"
 config/features=PackedStringArray("4.2")
+run/max_fps=60
 boot_splash/image="res://splash.png"
 boot_splash/use_filter=false
 config/icon="res://icon.png"
@@ -29,6 +30,7 @@ TouchControls="*res://classes/global/touch_control/touch_controls.tscn"
 
 window/size/viewport_width=640
 window/size/viewport_height=360
+window/vsync/vsync_mode=0
 mouse_cursor/custom_image="res://gui/cursor.png"
 mouse_cursor/custom_image_hotspot=Vector2(1, 1)
 


### PR DESCRIPTION
# Description of changes
Disabled v-sync and used an FPS cap of 60 instead.
This is done to combat the stuttery behavior the game displays as higher refresh rates. This stuttering only appears on frame rates higher than 60, not lower than 60. Having the FPS being capped at 60 effectively eliminates the issue. Note that v-sync does not help, as monitors can have higher refresh rates than 60, and thus the character still stutters.

# Disclaimer
This isn't exactly a fix, but rather a workaround. We should get behind the core of this issue some day, but for now this would suffice.

# Issue(s)
Closes #293 and possibly #268 