### PR TITLE
Drastically optimize pause menu elements

### DIFF
--- a/gui/hud/level_info.gd
+++ b/gui/hud/level_info.gd
@@ -9,11 +9,17 @@ var perm_scale = 1
 @onready var level_name = $Divider/MainContainer/LevelNamePanel/ScaleContainer/LevelName
 
 
-func _process(_delta):
-	# Update the font used, in case locale's changed.
-	if TranslationServer.get_locale().substr(0, 2) == "en":
-		level_name.add_theme_font_override("font", RUBY)
-		level_name.uppercase = true
-	else:
-		level_name.add_theme_font_override("font", BYLIGHT)
-		level_name.uppercase = false
+func _notification(what):
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		match TranslationServer.get_locale().substr(0, 2):
+			"en":
+				# Fancy display font has all needed characters.
+				# Use it for the level name.
+				level_name.add_theme_font_override("font", RUBY)
+				# Display font has only uppercase glyphs.
+				level_name.uppercase = true
+			_:
+				# Display font may not have all needed characters.
+				# Use the standard font.
+				level_name.add_theme_font_override("font", BYLIGHT)
+				level_name.uppercase = false

--- a/gui/hud/level_info.gd
+++ b/gui/hud/level_info.gd
@@ -3,9 +3,14 @@ extends Control
 const BYLIGHT = preload("res://fonts/bylight/bylight.otf")
 const RUBY = preload("res://fonts/red/gui_red.fnt")
 
-@onready var level_name = $Divider/MainContainer/LevelNamePanel/ScaleContainer/LevelName
 
 var perm_scale = 1
+
+@onready var level_name = $Divider/MainContainer/LevelNamePanel/ScaleContainer/LevelName
+
+
+func _process(_delta):
+	refresh_caps()
 
 
 func refresh_caps():
@@ -15,7 +20,3 @@ func refresh_caps():
 	else:
 		level_name.add_theme_font_override("font", BYLIGHT)
 		level_name.uppercase = false
-
-
-func _process(_delta):
-	refresh_caps()

--- a/gui/hud/level_info.gd
+++ b/gui/hud/level_info.gd
@@ -10,10 +10,7 @@ var perm_scale = 1
 
 
 func _process(_delta):
-	refresh_caps()
-
-
-func refresh_caps():
+	# Update the font used, in case locale's changed.
 	if TranslationServer.get_locale().substr(0, 2) == "en":
 		level_name.add_theme_font_override("font", RUBY)
 		level_name.uppercase = true

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -2,10 +2,11 @@ extends Button
 
 @export var action_id: String = ""
 
-@onready var key_list = $KeyList
-@onready var action_name = $ActionName
 var btn_scale: float: set = set_btn_scale
 var locale_saved: String = ""
+
+@onready var key_list = $KeyList
+@onready var action_name = $ActionName
 
 
 func _ready():

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -1,5 +1,11 @@
 extends Button
 
+enum GamepadBrand {
+	NINTENDO,
+	MICROSOFT,
+	SONY
+}
+
 @export var action_id: String = ""
 
 var btn_scale: float: set = set_btn_scale
@@ -41,7 +47,7 @@ func join_action_array(actions) -> String:
 			if action.button_index > buttons.size():
 				output += "(?)"
 			else:
-				output += "(%s)" % buttons[action.button_index][get_brand_id()]
+				output += "(%s)" % buttons[action.button_index][get_joypad_brand()]
 		elif action is InputEventJoypadMotion:
 			output += "(%s)" % get_joypad_motion_name(action.axis, action.axis_value)
 		else:
@@ -62,23 +68,6 @@ func _on_RebindOption_pressed():
 		Singleton.get_node("SFX/Next").play()
 		action_name.add_theme_color_override("font_color", Color.GREEN)
 		key_list.add_theme_color_override("font_color", Color.GREEN)
-		
-
-func get_brand_id(): # need to get the gamepad brand so we can display correct button icons
-	if Input.get_connected_joypads().size() > 0:
-		var guid = Input.get_joy_guid(0)
-		var vendor_id = guid.substr(8, 4)
-		match vendor_id:
-			"7e05": # nintendo
-				return 0
-			"5e04": # microsoft
-				return 1
-			"1716", "7264", "4c05", "510a", "ce0f", "ba12": # sony
-				return 2
-			_:
-				return 0
-	else:
-		return 0
 
 
 func _on_RebindOption_mouse_entered():
@@ -109,6 +98,23 @@ func get_joypad_motion_name(axis: int, value: float):
 			return tr("Right Stick Left") if value < 0 else tr("Right Stick Right")
 		JOY_AXIS_RIGHT_Y:
 			return tr("Right Stick Up") if value < 0 else tr("Right Stick Down")
+
+
+func get_joypad_brand(): # need to get the gamepad brand so we can display correct button icons
+	if Input.get_connected_joypads().size() > 0:
+		var guid = Input.get_joy_guid(0)
+		var vendor_id = guid.substr(8, 4)
+		match vendor_id:
+			"7e05":
+				return GamepadBrand.NINTENDO
+			"5e04":
+				return GamepadBrand.MICROSOFT
+			"1716", "7264", "4c05", "510a", "ce0f", "ba12":
+				return GamepadBrand.SONY
+			_:
+				return 0
+	else:
+		return 0
 
 
 func set_btn_scale(new_scale):

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -6,6 +6,9 @@ enum GamepadBrand {
 	SONY
 }
 
+## The currently set locale. Used to avoid repeating work between
+## rebind-option instances.
+static var locale_current: String
 ## 2D array of every button's name for every controller vendor.
 ## Some of these names have to be translateable, so it can't be const.
 static var joypad_buttons: Array
@@ -30,7 +33,6 @@ static var rstick_d: String
 @export var action_id: String = ""
 
 var btn_scale: float: set = set_btn_scale
-var locale_saved: String = ""
 
 @onready var key_list = $KeyList
 @onready var action_name = $ActionName
@@ -154,6 +156,8 @@ func set_btn_scale(new_scale):
 
 
 func _update_translations():
+	locale_current = TranslationServer.get_locale().substr(0, 2)
+
 	joypad_buttons = _get_joypad_buttons()
 	lstick_l = tr("Left Stick Left")
 	lstick_r = tr("Left Stick Right")
@@ -231,7 +235,9 @@ func _get_action_map() -> Dictionary:
 func _notification(what: int) -> void:
 	match what:
 		NOTIFICATION_TRANSLATION_CHANGED:
-			# TODO: Called once per rebind option. Could be called once total.
-			_update_translations()
+			# Update cached strings (but only if the first instance hasn't
+			# already done that).
+			if locale_current != TranslationServer.get_locale().substr(0, 2):
+				_update_translations()
 			# Update the list.
 			update_list()

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -9,6 +9,22 @@ enum GamepadBrand {
 ## 2D array of every button's name for every controller vendor.
 ## Some of these names have to be translateable, so it can't be const.
 static var joypad_buttons: Array
+## Translated name of input "Left Stick Left".
+static var lstick_l: String
+## Translated name of input "Left Stick Right".
+static var lstick_r: String
+## Translated name of input "Left Stick Up".
+static var lstick_u: String
+## Translated name of input "Left Stick Down".
+static var lstick_d: String
+## Translated name of input "Right Stick Left".
+static var rstick_l: String
+## Translated name of input "Right Stick Right".
+static var rstick_r: String
+## Translated name of input "Right Stick Up".
+static var rstick_u: String
+## Translated name of input "Right Stick Down".
+static var rstick_d: String
 
 
 @export var action_id: String = ""
@@ -27,7 +43,7 @@ func _ready():
 	# If another rebind hasn't cached it already, cache the appropriate set of
 	# joypad button names for this translation.
 	if len(joypad_buttons) == 0:
-		joypad_buttons = _get_joypad_buttons()
+		_update_translations()
 	
 	# Generate initial display name
 	update_list()
@@ -104,13 +120,13 @@ func unpress():
 func get_joypad_motion_name(axis: int, value: float):
 	match axis:
 		JOY_AXIS_LEFT_X:
-			return tr("Left Stick Left") if value < 0 else tr("Left Stick Right")
+			return lstick_l if value < 0 else lstick_r
 		JOY_AXIS_LEFT_Y:
-			return tr("Left Stick Up") if value < 0 else tr("Left Stick Down")
+			return lstick_u if value < 0 else lstick_d
 		JOY_AXIS_RIGHT_X:
-			return tr("Right Stick Left") if value < 0 else tr("Right Stick Right")
+			return rstick_l if value < 0 else rstick_r
 		JOY_AXIS_RIGHT_Y:
-			return tr("Right Stick Up") if value < 0 else tr("Right Stick Down")
+			return rstick_u if value < 0 else rstick_d
 
 
 func get_joypad_brand(): # need to get the gamepad brand so we can display correct button icons
@@ -135,6 +151,18 @@ func set_btn_scale(new_scale):
 	action_name.scale = Vector2.ONE * new_scale
 	key_list.scale = Vector2.ONE * new_scale
 	key_list.pivot_offset.x = key_list.size.x
+
+
+func _update_translations():
+	joypad_buttons = _get_joypad_buttons()
+	lstick_l = tr("Left Stick Left")
+	lstick_r = tr("Left Stick Right")
+	lstick_u = tr("Left Stick Up")
+	lstick_d = tr("Left Stick Down")
+	rstick_l = tr("Right Stick Left")
+	rstick_r = tr("Right Stick Right")
+	rstick_u = tr("Right Stick Up")
+	rstick_d = tr("Right Stick Down")
 
 
 func _get_joypad_buttons() -> Array:
@@ -166,6 +194,7 @@ func _get_joypad_buttons() -> Array:
 		[dpad_l, dpad_l, dpad_l],
 		[dpad_r, dpad_r, dpad_r],
 	]
+
 
 func _get_action_map() -> Dictionary:
 	return {
@@ -202,8 +231,7 @@ func _get_action_map() -> Dictionary:
 func _notification(what: int) -> void:
 	match what:
 		NOTIFICATION_TRANSLATION_CHANGED:
-			# Refresh the joypad button names.
 			# TODO: Called once per rebind option. Could be called once total.
-			joypad_buttons = _get_joypad_buttons()
+			_update_translations()
 			# Update the list.
 			update_list()

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -119,6 +119,15 @@ func set_btn_scale(new_scale):
 
 
 func _get_joypad_buttons() -> Array:
+	var start := tr("Start")
+	var click_ls := tr("Left Stick Click")
+	var click_rs := tr("Right Stick Click")
+	var logo := tr("Logo")
+	var dpad_u := tr("D-Up")
+	var dpad_d := tr("D-Down")
+	var dpad_l := tr("D-Left")
+	var dpad_r := tr("D-Right")
+	
 	return [
 		["B", "A", "X"],
 		["A", "B", "O"],
@@ -127,16 +136,16 @@ func _get_joypad_buttons() -> Array:
 		["L", "LB", "L1"],
 		["R", "RB", "R1"],
 		["-", tr("Back"), tr("Select")],
-		["+", tr("Start"), tr("Start")],
-		[tr("Left Stick Click"), tr("Left Stick Click"), tr("Left Stick Click")],
-		[tr("Right Stick Click"), tr("Right Stick Click"), tr("Right Stick Click")],
+		["+", start, start],
+		[click_ls, click_ls, click_ls],
+		[click_rs, click_rs, click_rs],
 		["ZL", "LT", "L2"],
 		["ZR", "RT", "R2"],
-		[tr("Logo"), tr("Logo"), tr("Logo")],
-		[tr("D-Up"), tr("D-Up"), tr("D-Up")],
-		[tr("D-Down"), tr("D-Down"), tr("D-Down")],
-		[tr("D-Left"), tr("D-Left"), tr("D-Left")],
-		[tr("D-Right"), tr("D-Right"), tr("D-Right")],
+		[logo, logo, logo],
+		[dpad_u, dpad_u, dpad_u],
+		[dpad_d, dpad_d, dpad_d],
+		[dpad_l, dpad_l, dpad_l],
+		[dpad_r, dpad_r, dpad_r],
 	]
 
 func _get_action_map() -> Dictionary:

--- a/gui/pause/options/rebind_option.gd
+++ b/gui/pause/options/rebind_option.gd
@@ -29,7 +29,10 @@ func _ready():
 	if len(joypad_buttons) == 0:
 		joypad_buttons = _get_joypad_buttons()
 	
+	# Generate initial display name
 	update_list()
+	# Update display name on resetting the keymap.
+	$"../../../ResetBinds".reset.connect(Callable(self, "update_list"))
 
 
 func _input(event):
@@ -40,10 +43,6 @@ func _input(event):
 			unpress()
 			Singleton.save_input_map(Singleton.get_input_map_json_current())
 			update_list()
-
-
-func _process(_delta):
-	update_list()
 
 
 func update_list():

--- a/gui/pause/options/reset_binds.gd
+++ b/gui/pause/options/reset_binds.gd
@@ -1,8 +1,17 @@
 extends TextureButton
 
+## Emitted immediately after the bindings have been reset.
+signal reset
+
 
 func _on_ResetBinds_pressed():
+	# Revert the input mapping, both in memory and on disk.
 	var map = Singleton.default_input_map
 	Singleton.load_input_map(map)
 	Singleton.save_input_map(map)
+	
+	# Announce to listeners that the map's been reset.
+	reset.emit()
+	
+	# Play a confirmation sound.
 	Singleton.get_node("SFX/Back").play()


### PR DESCRIPTION
# Description of changes
On profiling the normal gameplay loop, it was discovered that several pause menu elements had startlingly high performance costs. This PR optimizes them down to reasonable levels.

The bigger offender was the function `_get_joypad_buttons` in `rebind_option.gd`, which was profiled as using 11(!) ms of CPU time in each frame. This function returns an array of arrays of button names, indexed by logical button index and by controller brand. On inspection, it was found that this function was called once for every binding of every action, every frame, and doing the same 25 string translations every time (which suggests 25 disk reads). Assuming one binding for every action--which I know is lowballing it--that's `25 * 25 = 625` total translations per frame, literally 98% of which are repeated work.

Optimizing the script thus becomes a matter of reusing work. This can be done:
- within `_get_joypad_buttons`. Because some buttons share names between brands, some translated strings can be cached before constructing the return array, which skips 15 extra translations per function call. This step alone reduced CPU time from 11ms to 4ms.
- between actions and bindings. The result of calling `_get_joypad_buttons` doesn't depend on which action or mapping it's used for--only the selected locale. By storing the result in a static variable, it can be reused between instances, and the disk reads(?) involved in translation lookup can be skipped for all but the first user.
- between frames. Locale really only changes when the user sets it in the options menu, so for 99% of frames, `_get_joypad_buttons` returns the same result as last frame. `rebind_option` already has machinery to receive the engine's locale-change notification, so it's fairly trivial to only set `_get_joypad_buttons` when the game starts or the locale changes. Combined with the previous step, this reduced CPU time from 4ms to ~0.3ms, about level with `Entity._physics_process` and `DejitterGroup._physics_process`.
- Actually, the majority of `rebind_option`'s state doesn't change between frames. By adding (and connecting to) a signal to the reset-mappings button, it becomes possible to completely remove `_process` and instead update rebind options reactively. Naturally, this means `rebind_option` is no longer charting at all on most profiler frames.

Some similar string-caching-via-statics work was also done to `get_joypad_motion_name`. This is mostly for methodological consistency, but if somebody were to make very strange mapping choices ("wassup YouTube, today I'm gonna be playing SM63R using just the left and right analog stick!"), I could see it saving actual performance.

I also chose to optimize `level_info.gd`. This was much less of a problem script, but it still seemed appropriate to switch it from detecting locale via `_process` to detecting via engine notification, especially since `rebind_option` had shown me how to do that. This saves about 0.15ms--not much, but still seemed excessive for a static menu element.

Some mild refactors have also been sprinkled in, including obligatory reordering functions to standard and commenting everything I touch.