### PR TITLE
Refactor LD to use StringName item IDs instead of ints

### DIFF
--- a/scenes/menus/level_designer/item_pane.gd
+++ b/scenes/menus/level_designer/item_pane.gd
@@ -18,7 +18,7 @@ func _ready():
 
 
 func fill_grid():
-	for item_id in range(main.item_textures.size()):
+	for item_id in main.items.keys():
 		if main.item_textures[item_id] != null:
 			var button: LDListItem = LIST_ITEM.instantiate()
 			var tex: Texture

--- a/scenes/menus/level_designer/ld_item/ld_item.gd
+++ b/scenes/menus/level_designer/ld_item/ld_item.gd
@@ -39,7 +39,7 @@ const GLOW_MATERIAL = preload("res://shaders/glow.tres")
 ## 
 static var active_glow_mats = {}
 
-var item_id: int
+var item_id: StringName
 
 var glow_factor = 1
 var pulse = 0

--- a/scenes/menus/level_designer/ld_main.gd
+++ b/scenes/menus/level_designer/ld_main.gd
@@ -31,7 +31,8 @@ var item_static_properties = {}
 ##		[b]"default":[/b] Value the property defaults to on newly created
 ##			instances. If unset, the default value for the type will be used.
 ##			[br]
-##		[b]"increment":[/b] For spinners, amount up/down a single arrow click goes.[br]
+##		[b]"increment":[/b] For spinners, amount up/down a single arrow click goes.
+##			1 if unset.[br]
 ##		[b]"description":[/b] Description of the property, shown in tooltips.[br]
 var items: Array[Dictionary] = []
 ## Graphics for items to use.
@@ -340,9 +341,11 @@ func register_property(target, subname: String, type: String, parser: XMLParser)
 func implement_property(target, subname: String, type: String, parser: XMLParser):
 	var item_class_properties = _property_dictionary_of(target, subname, type)
 	
+	# Parse enough information from the XML that we can find the static property.
 	var prop_name = parser.get_named_attribute_value("label")
 	var get_prop = parser.get_named_attribute_value("name")
-	# NOTE: should we dupe this?
+	# Copy the static property into the item.
+	# NOTE: does the property need duping?
 	item_class_properties[prop_name] = item_static_properties[get_prop].duplicate()
 
 
@@ -368,7 +371,9 @@ func collect_property_values(parser: XMLParser) -> Dictionary:
 func inherit_class(target, subname: String, type: String, parser: XMLParser):
 	var item_class_properties = _property_dictionary_of(target, subname, type)
 	
+	# Pick class based on this XML node's name.
 	var parent_class = item_classes[parser.get_named_attribute_value("name")]
+	# Copy the class's properties into the item.
 	for key in parent_class:
 		item_class_properties[key] = parent_class[key]
 

--- a/scenes/menus/level_designer/ld_main.gd
+++ b/scenes/menus/level_designer/ld_main.gd
@@ -18,6 +18,7 @@ enum EDITOR_STATE { IDLE, PLACING, SELECTING, DRAGGING, POLYGON_CREATE, POLYGON_
 
 ## Definitions for base classes that items can implement.
 var item_classes = {}
+## Definitions for define-once properties that can be reused between items.
 var item_static_properties = {}
 ## Definitions for each type of item that can be placed.
 ## Each entry is a dictionary with the following properties:[br]

--- a/scenes/menus/level_designer/ld_main.gd
+++ b/scenes/menus/level_designer/ld_main.gd
@@ -328,17 +328,7 @@ func _read_items():
 
 ## Loads a property from the parsed XML into the target dictionary.
 func register_property(target, subname: String, type: String, parser: XMLParser):
-	# Decide which subset of the target we're writing to, based on type.
-	# Dictionaries and arrays are passed by reference, so by assigning the
-	# subset to item_class_properties, we get a window into the target.
-	var item_class_properties
-	if type == "item":
-		# Properties of items should be written into the desired item's
-		# properties dictionary.
-		item_class_properties = target[int(subname)].properties
-	else:
-		# Properties of anything else go directly into the desired thing.
-		item_class_properties = target[subname]
+	var item_class_properties = _property_dictionary_of(target, subname, type)
 	
 	# Write property values to the target, on the entry keyed to this
 	# XML node's label.
@@ -348,11 +338,7 @@ func register_property(target, subname: String, type: String, parser: XMLParser)
 ## Loads a predefined property, specified by the parsed XML,
 ## into the given target dictionary.
 func implement_property(target, subname: String, type: String, parser: XMLParser):
-	var item_class_properties
-	if type == "item":
-		item_class_properties = target[int(subname)].properties
-	else:
-		item_class_properties = target[subname]
+	var item_class_properties = _property_dictionary_of(target, subname, type)
 	
 	var prop_name = parser.get_named_attribute_value("label")
 	var get_prop = parser.get_named_attribute_value("name")
@@ -380,12 +366,23 @@ func collect_property_values(parser: XMLParser) -> Dictionary:
 ## Loads an entire set of predefined properties, specified by the parsed XML, 
 ## into the given target dictionary.
 func inherit_class(target, subname: String, type: String, parser: XMLParser):
-	var item_class_properties
-	if type == "item":
-		item_class_properties = target[int(subname)].properties
-	else:
-		item_class_properties = target[subname]
+	var item_class_properties = _property_dictionary_of(target, subname, type)
 	
 	var parent_class = item_classes[parser.get_named_attribute_value("name")]
 	for key in parent_class:
 		item_class_properties[key] = parent_class[key]
+
+
+## Returns a reference to the properties dictionary of the given target,
+## using type and subname to pick where to index and where to access.
+func _property_dictionary_of(target, subname: String, type: String) -> Dictionary:
+	# Decide which subset of the target we're writing to, based on type.
+	# Dictionaries and arrays are passed by reference, so returning a path to a
+	# subdictionary should get us a window into the target instead of a copy.
+	if type == "item":
+		# Properties of items should be written into the desired item's
+		# properties dictionary.
+		return target[int(subname)].properties
+	else:
+		# Properties of anything else go directly into the desired thing.
+		return target[subname]


### PR DESCRIPTION
# Description of changes
Exactly what it says on the tin. Also, comment and cleanup (I left some functions literally marked "does nothing" because I couldn't tell what they output--even though I knew commenting them out broke the code).

# Issue(s)
Meant to facilitate using human-readable item IDs when we switch to JSON level serialization.

# Future work
`items.xml.tres` still uses ints for its IDs. The ints are stored as strings, so it still works, but it's far from human-readable yet.