### PR TITLE
Fix background scaling in sized-up windows

### DIFF
--- a/backgrounds/zooming_parallax_background.gd
+++ b/backgrounds/zooming_parallax_background.gd
@@ -1,0 +1,7 @@
+extends ParallaxBackground
+
+
+func _process(delta):
+	var screen_scale := Singleton.get_screen_scale(1)
+	scale = Vector2.ONE * screen_scale
+	scroll_base_scale = Vector2.ONE / screen_scale

--- a/classes/player/camera.gd
+++ b/classes/player/camera.gd
@@ -2,26 +2,39 @@ extends Camera2D
 
 const ZOOM_TIME = 0.5
 
+const ZOOM_MAX = 4
+const ZOOM_MIN = 1
+
+
 var current_zoom: float = 1
 var prev_zoom: float = 1
 var target_zoom: float = 1
-var zoom_timer: float = 0
+
+## True when a zoom in/out animation is going.
 var rezooming: bool = false
+var zoom_timer: float = 0
+
 var target_limit_left = -10000000
 var target_limit_right = 10000000
 var target_limit_top = -10000000
 var target_limit_bottom = 10000000
+
 var first_frame = true
 
 
 func _ready():
+	# Set camera limits to a default too large to have an effect.
 	limit_left = -10000000
 	limit_right = 10000000
 	limit_top = -10000000
 	limit_bottom = 10000000
+
 	if get_path() != ^"/root/Main/Player/Camera":
+		# Clean up player cameras which don't belong to the first player.
+		# This comes into effect with cherry clones, and also ???.
 		queue_free()
 	else:
+		# Set first-player camera as active.
 		make_current()
 
 
@@ -29,42 +42,61 @@ func ease_out_expo(x: float) -> float:
 	return 1 - pow(2, -10 * x)
 
 
-func manage_zoom(delta) -> void:
-	var diff = target_zoom - prev_zoom
-	zoom_timer += delta
-	current_zoom = prev_zoom + diff * ease_out_expo(float(zoom_timer) / ZOOM_TIME)
-	if zoom_timer >= ZOOM_TIME:
-		current_zoom = target_zoom
-		rezooming = false
-
-
-func rezoom() -> void:
+## Begins a new zoom in/out animation.
+func begin_rezoom() -> void:
 	prev_zoom = current_zoom
 	zoom_timer = 0
 	rezooming = true
 
 
 func _process(delta):
+	# Advance the zoom in/out animation.
 	if rezooming:
-		manage_zoom(delta)
+		# Ease toward the target zoom level.
+		var dist_to_target = target_zoom - prev_zoom
+		current_zoom = prev_zoom + dist_to_target * ease_out_expo(zoom_timer / ZOOM_TIME)
+		
+		# Tick the zoom timer.
+		zoom_timer += delta
+		# When the zoom timer rings, snap to the target and consider 
+		# re-zooming finished.
+		# (The easing function is asymptotic--so if we don't snap, we'll never land
+		# exactly on the target zoom.)
+		if zoom_timer >= ZOOM_TIME:
+			current_zoom = target_zoom
+			rezooming = false
+	
+	
 	if get_window().size.x != 0:
-		var zoom_factor: float = 1 * float(Singleton.get_screen_scale(1))
+		# If the game is not paused, handle zoom in/out inputs.
 		if !get_tree().paused:
-			if Input.is_action_just_pressed("zoom+") and target_zoom < 4:
+			# Zoom in when button is pressed and not already at max zoom.
+			if Input.is_action_just_pressed("zoom+") and target_zoom < ZOOM_MAX:
+				# Each zoom-in step doubles the onscreen pixel size.
 				target_zoom *= 2
-				rezoom()
-			if Input.is_action_just_pressed("zoom-") and target_zoom > 1:
+				begin_rezoom()
+			
+			# Likewise for zooming out.
+			if Input.is_action_just_pressed("zoom-") and target_zoom > ZOOM_MIN:
+				# Each zoom-out step halves the onscreen pixel size.
 				target_zoom *= 0.5
-				rezoom()
-		zoom = Vector2.ONE * zoom_factor * current_zoom
+				begin_rezoom()
+		
+		# Apply the current zoom factor and screen scaling.
+		zoom = Vector2.ONE * current_zoom * Singleton.get_screen_scale(1)
+
 		if first_frame:
+			# Room just started. Immediately set position and limits to the
+			# destination.
+			position_smoothing_enabled = false
 			limit_left = target_limit_left
 			limit_right = target_limit_right
 			limit_top = target_limit_top
 			limit_bottom = target_limit_bottom
-			position_smoothing_enabled = false
+			
 			first_frame = false
 		else:
+			# Move smoothly to target position and limits.
 			position_smoothing_enabled = true
 			limit_left = lerp(limit_left, target_limit_left, 0.05)
 			limit_right = lerp(limit_right, target_limit_right, 0.05)

--- a/scenes/levels/tutorial_1/bg/bg_t1.tscn
+++ b/scenes/levels/tutorial_1/bg/bg_t1.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://dm0n1yq3d10ir"]
+[gd_scene load_steps=7 format=3 uid="uid://dm0n1yq3d10ir"]
 
 [ext_resource type="Texture2D" uid="uid://b70tcg0mwl806" path="res://scenes/levels/tutorial_1/bg/t1_layer_2.png" id="1"]
+[ext_resource type="Script" path="res://backgrounds/zooming_parallax_background.gd" id="1_g6svc"]
 [ext_resource type="Texture2D" uid="uid://0ef6u2gixkhc" path="res://scenes/levels/tutorial_1/bg/t1_layer_1.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://btjnqwmh8aevg" path="res://scenes/levels/tutorial_1/bg/t1_layer_0.png" id="3"]
 [ext_resource type="Script" path="res://backgrounds/scrolling_parallax_layer.gd" id="3_xsx85"]
@@ -9,6 +10,8 @@
 [node name="BGT1" type="ParallaxBackground"]
 process_mode = 3
 process_priority = 1
+scroll_ignore_camera_zoom = true
+script = ExtResource("1_g6svc")
 
 [node name="Sky" type="TextureRect" parent="."]
 anchors_preset = 15

--- a/scenes/levels/tutorial_1/bg/bg_t1.tscn
+++ b/scenes/levels/tutorial_1/bg/bg_t1.tscn
@@ -9,7 +9,6 @@
 [node name="BGT1" type="ParallaxBackground"]
 process_mode = 3
 process_priority = 1
-scroll_ignore_camera_zoom = true
 
 [node name="Sky" type="TextureRect" parent="."]
 anchors_preset = 15


### PR DESCRIPTION
# Description of changes
This has been on the backburner for way too long! Fixes background scaling so that sized-up windows don't show "backstage" parts of the background.

The parallax is not 100% consistent between scaling levels. I'm not sure how to fix this, but it's a very subtle problem that's (currently) easy to miss, so I'll leave it for now. We'll see how new backgrounds adapt to it....

# Issue(s)
Been reported many times, including by @GTcreyon.